### PR TITLE
fix(hub,e2e): graceful shutdown no longer hangs on long-poll connections

### DIFF
--- a/packages/hub/src/rest/server.test.ts
+++ b/packages/hub/src/rest/server.test.ts
@@ -62,3 +62,48 @@ describe('/api/sessions/:id/raw — streaming', () => {
     }
   });
 });
+
+describe('shutdown', () => {
+  it('close() resolves promptly even with active long-poll connections', async () => {
+    // Regression: graceful shutdown previously hung forever when long-lived
+    // chunked POSTs (e.g. raw byte ingest, sink-stream) were active —
+    // server.close() waits for every in-flight request to finish, but those
+    // never end on their own. Listen socket would close immediately, but
+    // the process kept event-looping on the active connections, leaving the
+    // hub half-dead (port not listening, but not exited either). Fix:
+    // server.closeAllConnections() force-terminates them so close resolves.
+    const registry = new SessionRegistry();
+    const tap = new PtyTap({ ringBytes: 4096 });
+    const server = createRestServer({ registry, tap });
+    await server.listen(0, '127.0.0.1');
+    const localPort = server.address().port;
+
+    const sid = 'longpoll-shutdown-test';
+    registry.register({ id: sid, name: 'n', agent: 'claude-code', cwd: '/tmp', pid: 1, sessionFilePath: '/tmp/x.jsonl' });
+
+    // Open a long-lived chunked POST (the canonical hang-causing pattern).
+    const req = httpRequest({
+      method: 'POST', host: '127.0.0.1', port: localPort,
+      path: `/api/sessions/${sid}/raw`,
+      headers: { 'content-type': 'application/octet-stream', 'transfer-encoding': 'chunked' },
+    });
+    req.on('error', () => {});
+    req.write('keepalive');
+    // Wait for the chunk to actually reach the server before testing close().
+    await new Promise((r) => setTimeout(r, 50));
+
+    // close() must resolve within a small bounded time even though req is
+    // still streaming. 1 second is generous; if the regression returns this
+    // would hang for the full test timeout (5s default).
+    const start = Date.now();
+    await Promise.race([
+      server.close(),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error('server.close() did not resolve within 1s')), 1000)),
+    ]);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+
+    req.destroy();
+  });
+});

--- a/packages/hub/src/rest/server.test.ts
+++ b/packages/hub/src/rest/server.test.ts
@@ -93,16 +93,15 @@ describe('shutdown', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     // close() must resolve within a small bounded time even though req is
-    // still streaming. 1 second is generous; if the regression returns this
-    // would hang for the full test timeout (5s default).
-    const start = Date.now();
+    // still streaming. The Promise.race below provides the deadline: if the
+    // regression returns the timeout side wins and the test fails via the
+    // rejected promise. (No wall-clock assertion — that's redundant and
+    // flake-prone on busy CI when the close resolves just before 1s.)
     await Promise.race([
       server.close(),
       new Promise((_resolve, reject) =>
         setTimeout(() => reject(new Error('server.close() did not resolve within 1s')), 1000)),
     ]);
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(1000);
 
     req.destroy();
   });

--- a/packages/hub/src/rest/server.ts
+++ b/packages/hub/src/rest/server.ts
@@ -105,9 +105,12 @@ export function createRestServer(deps: RestServerDeps): RestServer {
       // only stops accepting new connections and resolves only after every
       // in-flight request finishes — which never happens for those long-lived
       // connections, so plain close hangs forever on shutdown. Force-close
-      // the active sockets first.
-      server.closeAllConnections?.();   // node 18.2+
+      // the active sockets after stopping accept so the drain wait completes.
+      // Order is the canonical Node pattern: close() first (synchronously
+      // stops accepting + arms the callback), then closeAllConnections()
+      // destroys the remaining sockets so close()'s callback fires.
       server.close((e) => (e ? reject(e) : resolve()));
+      server.closeAllConnections?.();   // node 18.2+
     }),
     address: () => server.address() as AddressInfo,
   };

--- a/packages/hub/src/rest/server.ts
+++ b/packages/hub/src/rest/server.ts
@@ -99,7 +99,16 @@ export function createRestServer(deps: RestServerDeps): RestServer {
       server.once('error', reject);
       server.listen(port, host, () => { server.off('error', reject); resolve(); });
     }),
-    close: () => new Promise((resolve, reject) => server.close((e) => (e ? reject(e) : resolve()))),
+    close: () => new Promise((resolve, reject) => {
+      // Sesshin's REST server holds open long-poll connections (the CLI
+      // raw-byte ingest, sink-stream, and approval HTTP holds). server.close
+      // only stops accepting new connections and resolves only after every
+      // in-flight request finishes — which never happens for those long-lived
+      // connections, so plain close hangs forever on shutdown. Force-close
+      // the active sockets first.
+      server.closeAllConnections?.();   // node 18.2+
+      server.close((e) => (e ? reject(e) : resolve()));
+    }),
     address: () => server.address() as AddressInfo,
   };
 }

--- a/packages/hub/src/ws/server.test.ts
+++ b/packages/hub/src/ws/server.test.ts
@@ -414,3 +414,33 @@ describe('input.action stop bypasses canAcceptInput running-state gate', () => {
     }
   });
 });
+
+describe('WS server shutdown', () => {
+  it('close() resolves promptly even with an active WS client connected', async () => {
+    // Regression: previously close() did wss.close → http.close, but
+    // http.close waits for every in-flight HTTP-upgraded socket to drain.
+    // Long-lived WS clients never drain on their own, so the listen socket
+    // closed but the event loop kept the process alive forever — hub stuck
+    // half-dead (port not listening, but not exited either).
+    const localSvr = createWsServer({
+      registry: new SessionRegistry(), bus: new EventBus(),
+      tap: new PtyTap({ ringBytes: 1024 }), staticDir: null,
+    });
+    await localSvr.listen(0, '127.0.0.1');
+    const localPort = localSvr.address().port;
+
+    const ws = new WebSocket(`ws://127.0.0.1:${localPort}/v1/ws`);
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', resolve); ws.on('error', reject);
+    });
+
+    const start = Date.now();
+    await Promise.race([
+      localSvr.close(),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error('ws server close() did not resolve within 1s')), 1000)),
+    ]);
+    expect(Date.now() - start).toBeLessThan(1000);
+    if (ws.readyState !== WebSocket.CLOSED) ws.close();
+  });
+});

--- a/packages/hub/src/ws/server.test.ts
+++ b/packages/hub/src/ws/server.test.ts
@@ -434,13 +434,15 @@ describe('WS server shutdown', () => {
       ws.on('open', resolve); ws.on('error', reject);
     });
 
-    const start = Date.now();
+    // Promise.race below provides the 1s deadline; if the regression
+    // returns, the timeout side wins and the test fails via reject. (No
+    // wall-clock assertion — flake-prone on busy CI and redundant given
+    // race already enforces the bound.)
     await Promise.race([
       localSvr.close(),
       new Promise((_resolve, reject) =>
         setTimeout(() => reject(new Error('ws server close() did not resolve within 1s')), 1000)),
     ]);
-    expect(Date.now() - start).toBeLessThan(1000);
     if (ws.readyState !== WebSocket.CLOSED) ws.close();
   });
 });

--- a/packages/hub/src/ws/server.ts
+++ b/packages/hub/src/ws/server.ts
@@ -109,14 +109,15 @@ export function createWsServer(deps: WsServerDeps): WsServerInstance {
       for (const ws of sockets) ws.terminate();
       wss.close(() => {
         // http.close() only stops accepting new connections; it waits for
-        // every in-flight request to finish before resolving. Sesshin holds
-        // open long-lived requests (sink-stream, raw byte stream, heartbeat)
-        // for the lifetime of the wrapped CLI, so http.close alone hangs
-        // forever on shutdown — listen socket gone, but event loop alive
-        // because of the established connections. Force-close them so
-        // shutdown actually terminates.
-        http.closeAllConnections?.();   // node 18.2+
+        // every in-flight request to finish before resolving. Sesshin's
+        // long-lived requests would never end on their own, so plain close
+        // hangs forever — listen socket gone, but event loop alive on the
+        // established connections. Force-close them so shutdown finishes.
+        // Order is the canonical Node pattern: close() first (synchronously
+        // stops accepting + arms the callback), then closeAllConnections()
+        // destroys the remaining sockets so close()'s callback fires.
         http.close(() => resolve());
+        http.closeAllConnections?.();   // node 18.2+
       });
     }),
     address: () => http.address() as AddressInfo,

--- a/packages/hub/src/ws/server.ts
+++ b/packages/hub/src/ws/server.ts
@@ -107,7 +107,17 @@ export function createWsServer(deps: WsServerDeps): WsServerInstance {
     }),
     close: () => new Promise((resolve) => {
       for (const ws of sockets) ws.terminate();
-      wss.close(() => http.close(() => resolve()));
+      wss.close(() => {
+        // http.close() only stops accepting new connections; it waits for
+        // every in-flight request to finish before resolving. Sesshin holds
+        // open long-lived requests (sink-stream, raw byte stream, heartbeat)
+        // for the lifetime of the wrapped CLI, so http.close alone hangs
+        // forever on shutdown — listen socket gone, but event loop alive
+        // because of the established connections. Force-close them so
+        // shutdown actually terminates.
+        http.closeAllConnections?.();   // node 18.2+
+        http.close(() => resolve());
+      });
     }),
     address: () => http.address() as AddressInfo,
     broadcast: (msg) => {

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -16,10 +16,20 @@ const HOOK_BIN = join(ROOT, 'packages/hook-handler/bin/sesshin-hook-handler');
 // Only kill hubs that were spawned BY e2e runs (current or previous). Earlier
 // versions killed any process whose cmdline contained "sesshin-hub" — that
 // over-killed users' real running hubs in the same shell, taking down their
-// REST/WS listen sockets. e2e hubs always have HOME=/tmp/sesshin-e2e-* in
-// their environ (we set HOME below to isolate ~/.cache); real user hubs have
-// HOME under the user's home directory. Scope the kill via /proc/<pid>/environ.
+// REST/WS listen sockets. e2e hubs have HOME pointing into our per-run
+// tmpdir (set below); real user hubs have HOME under the user's home dir.
+// Scope the kill via /proc/<pid>/environ.
+//
+// Linux-only: macOS/Windows have no /proc, so this becomes a silent no-op
+// there. With this PR's shutdown fix landing, leaked hubs are rare enough
+// that the no-op is acceptable; investing in a cross-platform process-env
+// discovery (lsof/ps -E + parsing) is YAGNI for a Linux-only test env.
 function killLeftoverHubs() {
+  if (process.platform !== 'linux') return;
+  // Build the prefix at runtime so $TMPDIR is honored (default /tmp on
+  // Linux but configurable). Trailing slash + 'sesshin-e2e-' matches our
+  // mkdtempSync template below.
+  const e2eHomePrefix = `HOME=${tmpdir()}/sesshin-e2e-`;
   try {
     const out = execSync('ps -eo pid,args').toString();
     for (const line of out.split('\n')) {
@@ -28,13 +38,13 @@ function killLeftoverHubs() {
       if (!m) continue;
       const pid = Number(m[1]);
       // Read environ to confirm this hub belongs to a (previous) e2e run.
-      // /proc/<pid>/environ may be unreadable (perms, race) — in that case
-      // skip rather than risk a misfire.
+      // /proc/<pid>/environ may be unreadable (perms, race) — skip rather
+      // than risk a misfire.
       let environ = '';
       try { environ = readFileSync(`/proc/${pid}/environ`, 'utf-8'); } catch { continue; }
       const home = environ.split('\0').find((kv) => kv.startsWith('HOME='));
       if (!home) continue;
-      if (!home.startsWith('HOME=/tmp/sesshin-e2e-')) continue;
+      if (!home.startsWith(e2eHomePrefix)) continue;
       try { process.kill(pid); } catch {}
     }
   } catch {}

--- a/tests/e2e/run-e2e.mjs
+++ b/tests/e2e/run-e2e.mjs
@@ -2,7 +2,7 @@
 import { spawn, execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import WS from 'ws';
 
@@ -13,14 +13,29 @@ const HUB_BIN  = join(ROOT, 'packages/hub/bin/sesshin-hub');
 const CLI_BIN  = join(ROOT, 'packages/cli/bin/sesshin');
 const HOOK_BIN = join(ROOT, 'packages/hook-handler/bin/sesshin-hook-handler');
 
+// Only kill hubs that were spawned BY e2e runs (current or previous). Earlier
+// versions killed any process whose cmdline contained "sesshin-hub" — that
+// over-killed users' real running hubs in the same shell, taking down their
+// REST/WS listen sockets. e2e hubs always have HOME=/tmp/sesshin-e2e-* in
+// their environ (we set HOME below to isolate ~/.cache); real user hubs have
+// HOME under the user's home directory. Scope the kill via /proc/<pid>/environ.
 function killLeftoverHubs() {
   try {
     const out = execSync('ps -eo pid,args').toString();
     for (const line of out.split('\n')) {
-      if (line.includes('sesshin-hub') && !line.includes('grep')) {
-        const m = line.trim().match(/^(\d+)/);
-        if (m) { try { process.kill(Number(m[1])); } catch {} }
-      }
+      if (!line.includes('sesshin-hub') || line.includes('grep')) continue;
+      const m = line.trim().match(/^(\d+)/);
+      if (!m) continue;
+      const pid = Number(m[1]);
+      // Read environ to confirm this hub belongs to a (previous) e2e run.
+      // /proc/<pid>/environ may be unreadable (perms, race) — in that case
+      // skip rather than risk a misfire.
+      let environ = '';
+      try { environ = readFileSync(`/proc/${pid}/environ`, 'utf-8'); } catch { continue; }
+      const home = environ.split('\0').find((kv) => kv.startsWith('HOME='));
+      if (!home) continue;
+      if (!home.startsWith('HOME=/tmp/sesshin-e2e-')) continue;
+      try { process.kill(pid); } catch {}
     }
   } catch {}
 }


### PR DESCRIPTION
## Summary

- Hub `shutdown()` was hanging forever when long-poll connections were active (sink-stream, raw byte ingest, WS clients) — `http.close()` waits for every in-flight request to finish before resolving, so the listen socket got closed but the process never exited. Result: `:9662` / `:9663` stopped accepting clients, but the process kept running, leaving the hub permanently unreachable until manually killed.
- e2e `killLeftoverHubs()` matched any process whose cmdline contained `sesshin-hub` — including the developer's real running hub. Combined with bug #1, running `pnpm e2e` while having `sesshin claude` open in another terminal would leave the user's hub stuck half-dead.

## Fixes

### `packages/hub/src/rest/server.ts` + `packages/hub/src/ws/server.ts`

Call `server.closeAllConnections()` (node 18.2+, optional-chained) before `server.close()` so the in-flight long-poll connections are force-terminated. `http.close()` then resolves immediately.

### `tests/e2e/run-e2e.mjs`

Scope `killLeftoverHubs()` to processes whose `/proc/<pid>/environ` shows `HOME=/tmp/sesshin-e2e-*`. e2e isolates `HOME` to a per-run tmpdir; real user hubs always have `HOME` under the user's home directory. Skip on `/proc/.../environ` read failure rather than risk a misfire.

## Tests

- Two new regression tests — one each in `rest/server.test.ts` and `ws/server.test.ts` — that open a long-poll connection / WS client and assert `close()` resolves within 1 s. Without the fix these would hang for the test timeout.
- Full sweep: shared 33 / debug-web 19 / hub 304 (+2) / hook-handler 11 / cli 40, plus e2e PASS.

## Test plan

- [x] `pnpm test` (all packages)
- [x] `pnpm e2e`
- [x] Manual: previously-stuck `sesshin-hub` PID 616640 reproduced the bug; with the fix, `kill -TERM <hub>` now exits the process cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where servers would hang during shutdown when active long-lived streaming requests were present.

* **Tests**
  * Added regression tests verifying REST and WebSocket server shutdown completes promptly.
  * Enhanced end-to-end test suite cleanup to prevent interference between independent test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->