### PR TITLE
Render terminal output with xterm snapshots

### DIFF
--- a/link-latest.sh
+++ b/link-latest.sh
@@ -22,8 +22,10 @@ pnpm install
 printf '==> building workspace packages\n'
 pnpm build
 
-printf '==> linking root CLI package globally (sesshin)\n'
+printf '==> linking CLI package globally (sesshin)\n'
+cd "$ROOT_DIR/packages/cli"
 pnpm link --global
+cd "$ROOT_DIR"
 
 printf '==> linking hub package globally (sesshin-hub)\n'
 cd "$ROOT_DIR/packages/hub"

--- a/link-latest.sh
+++ b/link-latest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'error: required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+require_cmd node
+require_cmd pnpm
+
+printf '==> repo: %s\n' "$ROOT_DIR"
+cd "$ROOT_DIR"
+
+printf '==> installing workspace dependencies\n'
+pnpm install
+
+printf '==> building workspace packages\n'
+pnpm build
+
+printf '==> linking root CLI package globally (sesshin)\n'
+pnpm link --global
+
+printf '==> linking hub package globally (sesshin-hub)\n'
+cd "$ROOT_DIR/packages/hub"
+pnpm link --global
+cd "$ROOT_DIR"
+
+printf '\nDone. Linked commands should now resolve to this checkout.\n'
+printf 'Verify with:\n'
+printf '  command -v sesshin\n'
+printf '  command -v sesshin-hub\n'
+printf '  sesshin --help || true\n'
+printf '  sesshin-hub --help || true\n'

--- a/packages/cli/src/claude.ts
+++ b/packages/cli/src/claude.ts
@@ -64,6 +64,8 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
     body: JSON.stringify({
       id: sessionId, name: `claude (${cwd})`, agent: 'claude-code', cwd,
       pid: process.pid, sessionFilePath: sfp,
+      cols: process.stdout.columns ?? 80,
+      rows: process.stdout.rows ?? 24,
       initialPermissionMode,
       claudeAllowRules: claudeSettings.allowRules,
     }),
@@ -100,6 +102,20 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
     onInput: (data, _src) => wrap.write(data),
   });
 
+  const onResize = (): void => {
+    const cols = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    wrap.resize(cols, rows);
+    void fetch(`${HUB_URL}/api/sessions/${sessionId}/winsize`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cols, rows }),
+    }).catch(() => {});
+  };
+  process.stdout.on('resize', onResize);
+  onResize();
+
+
   // Shutdown is triggered by:
   //   (a) signal (SIGINT/SIGTERM) — via installCleanup's signal handlers
   //   (b) claude exiting naturally (`exit` / Ctrl+D) — via wrap.onExit
@@ -111,6 +127,7 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
     if (didShutdown) return;
     didShutdown = true;
     stopHeartbeat();
+    process.stdout.off('resize', onResize);
     tap.close();
     inject.close();
     try { await fetch(`${HUB_URL}/api/sessions/${sessionId}`, { method: 'DELETE' }); } catch {}

--- a/packages/cli/src/pty-tap.test.ts
+++ b/packages/cli/src/pty-tap.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { startPtyTap, type PtyTapHandle } from './pty-tap.js';
+
+interface FakeHub {
+  port: number;
+  received: () => Buffer;
+  close: () => Promise<void>;
+  /** Drop any in-flight connections so the client sees a 'close' event. */
+  drop: () => void;
+}
+
+async function startFakeHub(port = 0): Promise<FakeHub> {
+  let bytes = Buffer.alloc(0);
+  const server: Server = createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.endsWith('/raw')) {
+      res.writeHead(404).end();
+      return;
+    }
+    req.on('data', (c: Buffer) => {
+      bytes = Buffer.concat([bytes, c]);
+    });
+    req.on('end', () => {
+      if (!res.headersSent) res.writeHead(204).end();
+    });
+    req.on('error', () => {
+      /* ignore */
+    });
+  });
+  await new Promise<void>((r) => server.listen(port, r));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('no port');
+  return {
+    port: addr.port,
+    received: () => bytes,
+    drop: () => server.closeAllConnections?.(),
+    close: () =>
+      new Promise<void>((r) => {
+        server.closeAllConnections?.();
+        server.close(() => r());
+      }),
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const t0 = Date.now();
+  while (!predicate()) {
+    if (Date.now() - t0 > timeoutMs) throw new Error('waitFor timeout');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('startPtyTap', () => {
+  let tap: PtyTapHandle | null = null;
+  let hub: FakeHub | null = null;
+
+  afterEach(async () => {
+    tap?.close();
+    tap = null;
+    if (hub) await hub.close();
+    hub = null;
+  });
+
+  it('streams chunks to the hub while connected', async () => {
+    hub = await startFakeHub();
+    tap = startPtyTap({ hubUrl: `http://127.0.0.1:${hub.port}`, sessionId: 's1' });
+
+    tap.writeChunk('hello ');
+    tap.writeChunk('world');
+
+    await waitFor(() => hub!.received().toString('utf-8').includes('hello world'));
+    expect(hub.received().toString('utf-8')).toBe('hello world');
+  });
+
+  it('queues chunks while disconnected and flushes them after reconnect', async () => {
+    hub = await startFakeHub();
+    const port = hub.port;
+    tap = startPtyTap({
+      hubUrl: `http://127.0.0.1:${port}`,
+      sessionId: 's2',
+      initialBackoffMs: 30,
+      maxBackoffMs: 60,
+    });
+
+    tap.writeChunk('A');
+    await waitFor(() => hub!.received().toString('utf-8') === 'A');
+
+    // Bring the hub down mid-stream.
+    await hub.close();
+    hub = null;
+
+    // Give the client a moment to observe the disconnect (FIN/RST) so the next
+    // writes go through the queue instead of into a half-dead socket.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // These writes happen while disconnected — must be queued, not dropped.
+    tap.writeChunk('B');
+    tap.writeChunk('C');
+
+    // Bring a fresh hub up on the SAME port. The tap's reconnect should
+    // succeed and flush the queued bytes.
+    hub = await startFakeHub(port);
+    await waitFor(() => hub!.received().toString('utf-8') === 'BC', 5000);
+    expect(hub.received().toString('utf-8')).toBe('BC');
+  });
+
+  it('drops oldest queued chunks past queueMax while disconnected', async () => {
+    hub = await startFakeHub();
+    const port = hub.port;
+    tap = startPtyTap({
+      hubUrl: `http://127.0.0.1:${port}`,
+      sessionId: 's3',
+      initialBackoffMs: 30,
+      maxBackoffMs: 60,
+      queueMax: 3,
+    });
+
+    // Wait for initial connection.
+    tap.writeChunk('init');
+    await waitFor(() => hub!.received().toString('utf-8') === 'init');
+
+    await hub.close();
+    hub = null;
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    tap.writeChunk('1');
+    tap.writeChunk('2');
+    tap.writeChunk('3');
+    tap.writeChunk('4');
+    tap.writeChunk('5'); // should evict '1' and '2'
+
+    hub = await startFakeHub(port);
+    await waitFor(() => hub!.received().length > 0, 5000);
+    // Queue holds last 3: '3','4','5'
+    expect(hub.received().toString('utf-8')).toBe('345');
+  });
+
+  it('close() stops reconnect attempts and discards queued data', async () => {
+    hub = await startFakeHub();
+    const port = hub.port;
+    tap = startPtyTap({
+      hubUrl: `http://127.0.0.1:${port}`,
+      sessionId: 's4',
+      initialBackoffMs: 30,
+      maxBackoffMs: 60,
+    });
+
+    tap.writeChunk('x');
+    await waitFor(() => hub!.received().toString('utf-8') === 'x');
+
+    await hub.close();
+    hub = null;
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    tap.writeChunk('queued');
+    tap.close();
+
+    // Bring the hub back; tap should not reconnect and not deliver 'queued'.
+    hub = await startFakeHub(port);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(hub.received().length).toBe(0);
+  });
+});

--- a/packages/cli/src/pty-tap.ts
+++ b/packages/cli/src/pty-tap.ts
@@ -1,29 +1,138 @@
 // packages/cli/src/pty-tap.ts
-import { request } from 'node:http';
+import { request, type ClientRequest } from 'node:http';
 
-/** Stream raw PTY chunks to the hub. Reuses a single keep-alive connection per session. */
-export function startPtyTap(opts: { hubUrl: string; sessionId: string }): { writeChunk(data: string): void; close(): void } {
+export interface PtyTapHandle {
+  writeChunk(data: string): void;
+  close(): void;
+}
+
+export interface PtyTapOptions {
+  hubUrl: string;
+  sessionId: string;
+  /** Max queued chunks while reconnecting. Drops oldest on overflow. Default 1024. */
+  queueMax?: number;
+  /** Initial reconnect delay in ms (doubles up to maxBackoffMs). Default 100. */
+  initialBackoffMs?: number;
+  /** Cap for reconnect backoff. Default 5000. */
+  maxBackoffMs?: number;
+}
+
+/**
+ * Stream raw PTY chunks to the hub via a long-lived chunked POST.
+ *
+ * If the upstream connection drops (hub restarted, transient network), chunks
+ * received during the gap are queued (bounded ring) and flushed on the next
+ * successful reconnect, so late-joining web clients still see the full
+ * pre-reconnect history through the hub's snapshot mechanism.
+ */
+export function startPtyTap(opts: PtyTapOptions): PtyTapHandle {
   const url = new URL(opts.hubUrl);
   const port = Number(url.port);
-  let queue: Buffer[] = [];
-  let req: ReturnType<typeof request> | null = null;
+  const queueMax = opts.queueMax ?? 1024;
+  const initialBackoffMs = opts.initialBackoffMs ?? 100;
+  const maxBackoffMs = opts.maxBackoffMs ?? 5000;
+
+  const queue: Buffer[] = [];
+  let req: ClientRequest | null = null;
+  let connected = false;
+  let closed = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let backoffMs = initialBackoffMs;
+
+  const flushQueue = (): void => {
+    if (!req || isDestroyed(req)) return;
+    while (queue.length > 0) {
+      const buf = queue.shift()!;
+      const ok = req.write(buf);
+      if (!ok) {
+        req.once('drain', flushQueue);
+        return;
+      }
+    }
+  };
+
+  const scheduleReconnect = (): void => {
+    if (closed || reconnectTimer) return;
+    const delay = backoffMs;
+    backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      open();
+    }, delay);
+  };
 
   const open = (): void => {
-    req = request({
-      method: 'POST', host: url.hostname, port,
+    if (closed) return;
+    const r = request({
+      method: 'POST',
+      host: url.hostname,
+      port,
       path: `/api/sessions/${opts.sessionId}/raw`,
-      headers: { 'content-type': 'application/octet-stream', 'transfer-encoding': 'chunked' },
+      headers: {
+        'content-type': 'application/octet-stream',
+        'transfer-encoding': 'chunked',
+      },
     });
-    req.on('error', () => { req = null; });
+    req = r;
+    connected = false;
+
+    const teardown = (): void => {
+      if (req === r) {
+        req = null;
+        connected = false;
+      }
+      scheduleReconnect();
+    };
+
+    r.on('error', teardown);
+    r.on('close', teardown);
+    r.on('socket', (sock) => {
+      const onConnect = (): void => {
+        connected = true;
+        backoffMs = initialBackoffMs;
+        flushQueue();
+      };
+      if ((sock as { connecting?: boolean }).connecting === false) {
+        // Already connected (e.g., reused agent socket).
+        onConnect();
+      } else {
+        sock.once('connect', onConnect);
+      }
+    });
   };
 
   open();
+
   return {
-    writeChunk(data) {
+    writeChunk(data: string): void {
+      if (closed) return;
       const buf = Buffer.from(data, 'utf-8');
-      if (req && !(req as unknown as { destroyed?: boolean }).destroyed) { req.write(buf); }
-      else { queue.push(buf); if (queue.length > 64) queue.shift(); /* drop oldest */ }
+      if (req && connected && req.writable && !isDestroyed(req)) {
+        req.write(buf);
+        return;
+      }
+      queue.push(buf);
+      while (queue.length > queueMax) queue.shift();
     },
-    close() { if (req) { req.end(); req = null; } },
+    close(): void {
+      closed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (req && !isDestroyed(req)) {
+        try {
+          req.end();
+        } catch {
+          /* ignore */
+        }
+      }
+      req = null;
+      queue.length = 0;
+    },
   };
+}
+
+function isDestroyed(r: ClientRequest): boolean {
+  return Boolean((r as unknown as { destroyed?: boolean }).destroyed);
 }

--- a/packages/cli/src/pty-tap.ts
+++ b/packages/cli/src/pty-tap.ts
@@ -27,7 +27,9 @@ export interface PtyTapOptions {
  */
 export function startPtyTap(opts: PtyTapOptions): PtyTapHandle {
   const url = new URL(opts.hubUrl);
-  const port = Number(url.port);
+  // url.port is '' when the URL omits an explicit port; Number('') is 0,
+  // which is invalid. Default by protocol so http://host/path also works.
+  const port = url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80);
   const queueMax = opts.queueMax ?? 1024;
   const initialBackoffMs = opts.initialBackoffMs ?? 100;
   const maxBackoffMs = opts.maxBackoffMs ?? 5000;
@@ -107,12 +109,13 @@ export function startPtyTap(opts: PtyTapOptions): PtyTapHandle {
     writeChunk(data: string): void {
       if (closed) return;
       const buf = Buffer.from(data, 'utf-8');
-      if (req && connected && req.writable && !isDestroyed(req)) {
-        req.write(buf);
-        return;
-      }
+      // Always enqueue first, then flush. Routing through the queue keeps the
+      // bound (queueMax) honored and ensures backpressure observed during
+      // flushQueue (req.write returning false → drain wait) doesn't get
+      // bypassed by a fast-path write.
       queue.push(buf);
       while (queue.length > queueMax) queue.shift();
+      if (req && connected && req.writable && !isDestroyed(req)) flushQueue();
     },
     close(): void {
       closed = true;

--- a/packages/debug-web/package.json
+++ b/packages/debug-web/package.json
@@ -10,9 +10,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@preact/signals": "^1.3.0",
     "@sesshin/shared": "workspace:*",
-    "preact": "^10.24.0",
-    "@preact/signals": "^1.3.0"
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
+    "preact": "^10.24.0"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.9.0",

--- a/packages/debug-web/src/components/SessionDetail.tsx
+++ b/packages/debug-web/src/components/SessionDetail.tsx
@@ -1,4 +1,5 @@
-import { selectedSession, summariesBySession, eventsBySession, rawBySession } from '../store.js';
+import { useState } from 'preact/hooks';
+import { selectedSession, summariesBySession, eventsBySession } from '../store.js';
 import { StateBadge } from './StateBadge.js';
 import { ModeBadge } from './ModeBadge.js';
 import { SummaryCard } from './SummaryCard.js';
@@ -7,18 +8,31 @@ import { ActionButtons } from './ActionButtons.js';
 import { TextInput } from './TextInput.js';
 import { InteractionPanel } from './InteractionPanel.js';
 import { CopyBtn } from './CopyBtn.js';
+import { TerminalView } from './TerminalView.js';
 import type { WsClient } from '../ws-client.js';
-
-function stripAnsi(s: string): string {
-  return s.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
-}
 
 export function SessionDetail({ ws }: { ws: WsClient }) {
   const s = selectedSession.value;
+  const [tab, setTab] = useState<'summary' | 'events' | 'terminal'>('summary');
   if (!s) return <div style={{ padding: 24, opacity: 0.5 }}>select a session</div>;
   const summaries = summariesBySession.value[s.id] ?? [];
   const events = eventsBySession.value[s.id] ?? [];
-  const raw = rawBySession.value[s.id] ?? '';
+  const tabButton = (key: 'summary' | 'events' | 'terminal', label: string) => (
+    <button
+      onClick={() => setTab(key)}
+      style={{
+        background: tab === key ? '#2a2a2a' : '#111',
+        color: '#eee',
+        border: '1px solid #333',
+        borderRadius: 6,
+        padding: '6px 10px',
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  );
+
   return (
     <div style={{ padding: 16, color: '#eee' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 6 }}>
@@ -40,18 +54,19 @@ export function SessionDetail({ ws }: { ws: WsClient }) {
           <CopyBtn text={s.sessionFilePath} label="copy path" />
         </div>
       )}
-      <SummaryCard summary={summaries[0] ?? null} />
       <InteractionPanel ws={ws} sessionId={s.id} />
       <ActionButtons ws={ws} sessionId={s.id} />
       <TextInput ws={ws} sessionId={s.id} />
-      <h3>Event timeline</h3>
-      <EventTimeline events={events} />
-      <h3>Terminal output (last 16 KiB)</h3>
-      <pre style={{
-        background: '#000', color: '#ccc', padding: 8, borderRadius: 4,
-        maxHeight: 200, overflowY: 'auto', fontFamily: 'monospace', fontSize: 12,
-        whiteSpace: 'pre-wrap', wordBreak: 'break-all',
-      }}>{stripAnsi(raw)}</pre>
+
+      <div style={{ display: 'flex', gap: 8, margin: '16px 0 12px 0' }}>
+        {tabButton('summary', 'Summary')}
+        {tabButton('events', 'Events')}
+        {tabButton('terminal', 'Terminal')}
+      </div>
+
+      {tab === 'summary' && <SummaryCard summary={summaries[0] ?? null} />}
+      {tab === 'events' && <EventTimeline events={events} />}
+      {tab === 'terminal' && <TerminalView ws={ws} sessionId={s.id} />}
     </div>
   );
 }

--- a/packages/debug-web/src/components/TerminalView.tsx
+++ b/packages/debug-web/src/components/TerminalView.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import type { ITheme } from '@xterm/xterm';
+import type { WsClient } from '../ws-client.js';
+import {
+  terminalThemes,
+  type TerminalThemeKey,
+  loadTerminalThemeKey,
+  saveTerminalThemeKey,
+  loadCustomTerminalThemeText,
+  saveCustomTerminalThemeText,
+  parseCustomTerminalTheme,
+} from '../terminal-themes.js';
+
+function decodeBase64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function themeFromSelection(selection: TerminalThemeKey | 'custom', customText: string): ITheme {
+  if (selection === 'custom') return parseCustomTerminalTheme(customText) ?? terminalThemes.default.theme;
+  return terminalThemes[selection].theme;
+}
+
+export function TerminalView({ ws, sessionId }: { ws: WsClient; sessionId: string }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const readyRef = useRef(false);
+  const queueRef = useRef<Uint8Array[]>([]);
+  const seqRef = useRef(0);
+
+  const [themeSelection, setThemeSelection] = useState<TerminalThemeKey | 'custom'>(() => loadTerminalThemeKey());
+  const [customThemeText, setCustomThemeText] = useState<string>(() => loadCustomTerminalThemeText());
+  const [customThemeError, setCustomThemeError] = useState<string | null>(null);
+
+  const theme = useMemo(() => themeFromSelection(themeSelection, customThemeText), [themeSelection, customThemeText]);
+
+  useEffect(() => {
+    const term = new Terminal({
+      theme,
+      scrollback: 10_000,
+      disableStdin: true,
+      cursorBlink: false,
+      fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+      fontSize: 12,
+      convertEol: false,
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(containerRef.current!);
+    fit.fit();
+    terminalRef.current = term;
+    fitRef.current = fit;
+
+    const observer = new ResizeObserver(() => {
+      try { fit.fit(); } catch { /* ignore */ }
+    });
+    observer.observe(containerRef.current!);
+
+    const unsubscribe = ws.subscribeTerminal(sessionId, (message) => {
+      if (message.type === 'terminal.snapshot') {
+        readyRef.current = false;
+        queueRef.current = [];
+        seqRef.current = message.seq;
+        term.reset();
+        term.resize(message.cols, message.rows);
+        if (message.data) term.write(message.data);
+        readyRef.current = true;
+        for (const chunk of queueRef.current) term.write(chunk);
+        queueRef.current = [];
+        return;
+      }
+      if (message.type === 'terminal.delta') {
+        if (message.seq <= seqRef.current) return;
+        const bytes = decodeBase64ToBytes(message.data);
+        seqRef.current = message.seq;
+        if (!readyRef.current) {
+          queueRef.current.push(bytes);
+          return;
+        }
+        term.write(bytes);
+        return;
+      }
+      if (message.type === 'terminal.resize') {
+        term.resize(message.cols, message.rows);
+        return;
+      }
+      if (message.type === 'terminal.ended') {
+        term.write(`\r\n\x1b[90m[terminal ended${message.reason ? `: ${message.reason}` : ''}]\x1b[0m\r\n`);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      observer.disconnect();
+      fitRef.current = null;
+      terminalRef.current = null;
+      term.dispose();
+    };
+  }, [sessionId, ws]);
+
+  useEffect(() => {
+    saveTerminalThemeKey(themeSelection);
+    const term = terminalRef.current;
+    if (term) term.options.theme = theme;
+  }, [theme, themeSelection]);
+
+  useEffect(() => {
+    saveCustomTerminalThemeText(customThemeText);
+    setCustomThemeError(themeSelection === 'custom' && !parseCustomTerminalTheme(customThemeText)
+      ? 'Custom theme JSON must parse to an object.'
+      : null);
+  }, [customThemeText, themeSelection]);
+
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <label style={{ fontSize: 12, opacity: 0.8 }}>
+          theme{' '}
+          <select
+            value={themeSelection}
+            onChange={(e) => setThemeSelection((e.currentTarget.value as TerminalThemeKey | 'custom'))}
+            style={{ background: '#111', color: '#eee', border: '1px solid #333', borderRadius: 4, padding: '4px 6px' }}
+          >
+            {Object.entries(terminalThemes).map(([key, value]) => (
+              <option key={key} value={key}>{value.name}</option>
+            ))}
+            <option value="custom">Custom JSON</option>
+          </select>
+        </label>
+      </div>
+      {themeSelection === 'custom' && (
+        <div style={{ display: 'grid', gap: 6 }}>
+          <textarea
+            value={customThemeText}
+            onInput={(e) => setCustomThemeText(e.currentTarget.value)}
+            rows={8}
+            style={{ background: '#111', color: '#ddd', border: '1px solid #333', borderRadius: 4, padding: 8, fontFamily: 'monospace', fontSize: 12 }}
+          />
+          {customThemeError && <div style={{ color: '#f88', fontSize: 12 }}>{customThemeError}</div>}
+        </div>
+      )}
+      <div
+        ref={containerRef}
+        style={{
+          background: '#000',
+          border: '1px solid #222',
+          borderRadius: 6,
+          minHeight: 260,
+          height: 420,
+          overflow: 'hidden',
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/debug-web/src/store.test.ts
+++ b/packages/debug-web/src/store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   sessions, upsertSession, removeSession,
   promptRequestsBySession, addPromptRequest,
-  summariesBySession, eventsBySession, rawBySession,
+  summariesBySession, eventsBySession,
 } from './store.js';
 
 describe('removeSession side-effects', () => {
@@ -11,7 +11,6 @@ describe('removeSession side-effects', () => {
     promptRequestsBySession.value = {};
     summariesBySession.value = {};
     eventsBySession.value = {};
-    rawBySession.value = {};
   });
 
   it('clears promptRequestsBySession[id] when removing a session', () => {
@@ -32,7 +31,7 @@ describe('removeSession side-effects', () => {
     expect(promptRequestsBySession.value['s1']).toBeUndefined();
   });
 
-  it('clears summariesBySession / eventsBySession / rawBySession on removeSession', () => {
+  it('clears summariesBySession / eventsBySession on removeSession', () => {
     upsertSession({
       id: 's2', name: 'n', agent: 'claude-code', cwd: '/x', pid: 1,
       startedAt: 0, state: 'idle' as any, substate: {} as any,
@@ -41,12 +40,10 @@ describe('removeSession side-effects', () => {
     // Seed each map directly
     summariesBySession.value = { s2: [{ summaryId: 'sum-1' } as any] };
     eventsBySession.value = { s2: [{ eventId: 'e1' } as any] };
-    rawBySession.value = { s2: 'data' };
 
     removeSession('s2');
 
     expect(summariesBySession.value['s2']).toBeUndefined();
     expect(eventsBySession.value['s2']).toBeUndefined();
-    expect(rawBySession.value['s2']).toBeUndefined();
   });
 });

--- a/packages/debug-web/src/store.ts
+++ b/packages/debug-web/src/store.ts
@@ -23,7 +23,6 @@ export const sessions = signal<SessionInfo[]>([]);
 export const selectedSessionId = signal<string | null>(null);
 export const summariesBySession = signal<Record<string, Summary[]>>({});
 export const eventsBySession = signal<Record<string, Event[]>>({});
-export const rawBySession = signal<Record<string, string>>({});
 export const promptRequestsBySession = signal<Record<string, PendingPromptRequest[]>>({});
 export const connected = signal<boolean>(false);
 export const lastEventId = signal<string | null>(null);
@@ -53,7 +52,6 @@ export function removeSession(id: string): void {
   // Prevents stale entries lingering after the agent exits / unregisters.
   deleteSessionKey(summariesBySession, id);
   deleteSessionKey(eventsBySession, id);
-  deleteSessionKey(rawBySession, id);
   deleteSessionKey(promptRequestsBySession, id);
 }
 
@@ -89,13 +87,6 @@ export function addEvent(e: Event): void {
   const cur = eventsBySession.value[e.sessionId] ?? [];
   eventsBySession.value = { ...eventsBySession.value, [e.sessionId]: [e, ...cur].slice(0, 200) };
   lastEventId.value = e.eventId;
-}
-
-export function appendRaw(sessionId: string, data: string): void {
-  const cur = rawBySession.value[sessionId] ?? '';
-  // Keep last ~16 KiB per session to avoid unbounded memory.
-  const next = (cur + data).slice(-16_384);
-  rawBySession.value = { ...rawBySession.value, [sessionId]: next };
 }
 
 export function addPromptRequest(c: PendingPromptRequest): void {

--- a/packages/debug-web/src/terminal-themes.ts
+++ b/packages/debug-web/src/terminal-themes.ts
@@ -1,0 +1,80 @@
+import type { ITheme } from '@xterm/xterm';
+
+export const terminalThemes = {
+  default: {
+    name: 'Default',
+    theme: { background: '#000000', foreground: '#cccccc' } satisfies ITheme,
+  },
+  solarizedDark: {
+    name: 'Solarized Dark',
+    theme: {
+      background: '#002b36', foreground: '#93a1a1', black: '#073642', red: '#dc322f', green: '#859900',
+      yellow: '#b58900', blue: '#268bd2', magenta: '#d33682', cyan: '#2aa198', white: '#eee8d5',
+      brightBlack: '#586e75', brightRed: '#cb4b16', brightGreen: '#586e75', brightYellow: '#657b83',
+      brightBlue: '#839496', brightMagenta: '#6c71c4', brightCyan: '#93a1a1', brightWhite: '#fdf6e3',
+    } satisfies ITheme,
+  },
+  dracula: {
+    name: 'Dracula',
+    theme: {
+      background: '#282a36', foreground: '#f8f8f2', black: '#21222c', red: '#ff5555', green: '#50fa7b',
+      yellow: '#f1fa8c', blue: '#bd93f9', magenta: '#ff79c6', cyan: '#8be9fd', white: '#f8f8f2',
+      brightBlack: '#6272a4', brightRed: '#ff6e6e', brightGreen: '#69ff94', brightYellow: '#ffffa5',
+      brightBlue: '#d6acff', brightMagenta: '#ff92df', brightCyan: '#a4ffff', brightWhite: '#ffffff',
+    } satisfies ITheme,
+  },
+  gruvboxDark: {
+    name: 'Gruvbox Dark',
+    theme: {
+      background: '#282828', foreground: '#ebdbb2', black: '#282828', red: '#cc241d', green: '#98971a',
+      yellow: '#d79921', blue: '#458588', magenta: '#b16286', cyan: '#689d6a', white: '#a89984',
+      brightBlack: '#928374', brightRed: '#fb4934', brightGreen: '#b8bb26', brightYellow: '#fabd2f',
+      brightBlue: '#83a598', brightMagenta: '#d3869b', brightCyan: '#8ec07c', brightWhite: '#fbf1c7',
+    } satisfies ITheme,
+  },
+  light: {
+    name: 'Light',
+    theme: { background: '#ffffff', foreground: '#111111' } satisfies ITheme,
+  },
+} as const;
+
+export type TerminalThemeKey = keyof typeof terminalThemes;
+
+export const terminalThemeStorageKey = 'sesshin.terminalTheme';
+export const terminalCustomThemeStorageKey = 'sesshin.terminalTheme.custom';
+
+export function isTerminalThemeKey(value: string): value is TerminalThemeKey {
+  return value in terminalThemes;
+}
+
+export function loadTerminalThemeKey(): TerminalThemeKey | 'custom' {
+  if (typeof localStorage === 'undefined') return 'default';
+  const raw = localStorage.getItem(terminalThemeStorageKey);
+  if (raw === 'custom') return 'custom';
+  return raw && isTerminalThemeKey(raw) ? raw : 'default';
+}
+
+export function saveTerminalThemeKey(value: TerminalThemeKey | 'custom'): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(terminalThemeStorageKey, value);
+}
+
+export function loadCustomTerminalThemeText(): string {
+  if (typeof localStorage === 'undefined') return '{\n  "background": "#000000",\n  "foreground": "#cccccc"\n}';
+  return localStorage.getItem(terminalCustomThemeStorageKey)
+    ?? '{\n  "background": "#000000",\n  "foreground": "#cccccc"\n}';
+}
+
+export function saveCustomTerminalThemeText(value: string): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(terminalCustomThemeStorageKey, value);
+}
+
+export function parseCustomTerminalTheme(text: string): ITheme | null {
+  try {
+    const value = JSON.parse(text) as ITheme;
+    return typeof value === 'object' && value !== null ? value : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/debug-web/src/ws-client.ts
+++ b/packages/debug-web/src/ws-client.ts
@@ -1,66 +1,96 @@
-// packages/debug-web/src/ws-client.ts
 import {
   connected, sessions, upsertSession, removeSession,
-  addSummary, addEvent, appendRaw, lastEventId,
+  addSummary, addEvent, lastEventId,
   addPromptRequest, removePromptRequest,
   applyConfigChanged, applyChildSessionChanged,
 } from './store.js';
 import type { Action, PromptResponseAnswer } from '@sesshin/shared';
 
+export interface TerminalSnapshotMessage {
+  type: 'terminal.snapshot';
+  sessionId: string;
+  seq: number;
+  cols: number;
+  rows: number;
+  data: string;
+}
+
+export interface TerminalDeltaMessage {
+  type: 'terminal.delta';
+  sessionId: string;
+  seq: number;
+  data: string;
+}
+
+export interface TerminalResizeMessage {
+  type: 'terminal.resize';
+  sessionId: string;
+  cols: number;
+  rows: number;
+}
+
+export interface TerminalEndedMessage {
+  type: 'terminal.ended';
+  sessionId: string;
+  reason?: string | null;
+}
+
+export type TerminalMessage =
+  | TerminalSnapshotMessage
+  | TerminalDeltaMessage
+  | TerminalResizeMessage
+  | TerminalEndedMessage;
+
 export interface WsClient {
   sendAction(sessionId: string, action: Action): void;
   sendText(sessionId: string, text: string): void;
   sendPromptResponse(sessionId: string, requestId: string, answers: PromptResponseAnswer[]): void;
+  subscribeTerminal(sessionId: string, onMessage: (message: TerminalMessage) => void): () => void;
   close(): void;
 }
 
-export function connect(): WsClient {
-  const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/v1/ws`;
-  let ws: WebSocket | null = null;
-  let backoff = 500;
+const terminalListeners = new Map<string, Set<(message: TerminalMessage) => void>>();
+let currentSocket: WebSocket | null = null;
 
-  const open = (): void => {
-    ws = new WebSocket(url);
-    ws.addEventListener('open', () => {
-      connected.value = true; backoff = 500;
-      ws!.send(JSON.stringify({
-        type: 'client.identify', protocol: 1,
-        client: { kind: 'debug-web', version: '0.0.0',
-          capabilities: ['summary','events','raw','actions','state','attention'] },
-      }));
-      ws!.send(JSON.stringify({ type: 'subscribe', sessions: 'all', since: lastEventId.value }));
-    });
-    ws.addEventListener('message', (e) => handleFrame(JSON.parse(e.data)));
-    ws.addEventListener('close', () => { connected.value = false; setTimeout(open, backoff); backoff = Math.min(backoff * 2, 10_000); });
-    ws.addEventListener('error', () => ws?.close());
-  };
-  open();
+function sendFrame(payload: object): void {
+  currentSocket?.send(JSON.stringify(payload));
+}
 
-  return {
-    sendAction(sessionId, action) { ws?.send(JSON.stringify({ type: 'input.action', sessionId, action })); },
-    sendText(sessionId, text)     { ws?.send(JSON.stringify({ type: 'input.text', sessionId, text })); },
-    sendPromptResponse(sessionId, requestId, answers) {
-      ws?.send(JSON.stringify({ type: 'prompt-response', sessionId, requestId, answers }));
-    },
-    close() { ws?.close(); },
-  };
+function emitTerminal(message: TerminalMessage): void {
+  const listeners = terminalListeners.get(message.sessionId);
+  if (!listeners) return;
+  for (const listener of listeners) listener(message);
+}
+
+function rehydrateTerminalSubscriptions(): void {
+  for (const sessionId of terminalListeners.keys()) {
+    sendFrame({ type: 'terminal.subscribe', sessionId });
+  }
+}
+
+function handleTerminalFrame(m: any): boolean {
+  if (m.type === 'terminal.snapshot' || m.type === 'terminal.delta' || m.type === 'terminal.resize' || m.type === 'terminal.ended') {
+    emitTerminal(m as TerminalMessage);
+    return true;
+  }
+  return false;
 }
 
 function handleFrame(m: any): void {
+  if (handleTerminalFrame(m)) return;
   switch (m.type) {
     case 'server.hello': return;
-    case 'server.ping': /* (server.pong handler if hub adds one in v1.5) */ return;
+    case 'server.ping': return;
     case 'session.list':    sessions.value = m.sessions; return;
     case 'session.added':   upsertSession(m.session); return;
     case 'session.removed': removeSession(m.sessionId); return;
-    case 'session.state':   {
+    case 'session.state': {
       const cur = sessions.value.find((s) => s.id === m.sessionId);
       if (cur) upsertSession({ ...cur, state: m.state, substate: m.substate });
       return;
     }
     case 'session.summary': addSummary(m); return;
     case 'session.event':   addEvent(m); return;
-    case 'session.raw':     appendRaw(m.sessionId, m.data); return;
     case 'session.prompt-request':
       addPromptRequest({
         sessionId: m.sessionId, requestId: m.requestId,
@@ -78,6 +108,66 @@ function handleFrame(m: any): void {
     case 'session.child-changed':
       applyChildSessionChanged(m.sessionId, m.claudeSessionId);
       return;
-    // attention is accepted but not rendered yet (T64).
   }
+}
+
+export function connect(): WsClient {
+  const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/v1/ws`;
+  let ws: WebSocket | null = null;
+  let backoff = 500;
+
+  const open = (): void => {
+    ws = new WebSocket(url);
+    currentSocket = ws;
+    ws.addEventListener('open', () => {
+      connected.value = true;
+      backoff = 500;
+      ws!.send(JSON.stringify({
+        type: 'client.identify', protocol: 1,
+        client: { kind: 'debug-web', version: '0.0.0', capabilities: ['summary','events','terminal','actions','state','attention'] },
+      }));
+      ws!.send(JSON.stringify({ type: 'subscribe', sessions: 'all', since: lastEventId.value }));
+      rehydrateTerminalSubscriptions();
+    });
+    ws.addEventListener('message', (e) => handleFrame(JSON.parse(e.data)));
+    ws.addEventListener('close', () => {
+      connected.value = false;
+      currentSocket = null;
+      setTimeout(open, backoff);
+      backoff = Math.min(backoff * 2, 10_000);
+    });
+    ws.addEventListener('error', () => ws?.close());
+  };
+  open();
+
+  return {
+    sendAction(sessionId, action) { ws?.send(JSON.stringify({ type: 'input.action', sessionId, action })); },
+    sendText(sessionId, text) { ws?.send(JSON.stringify({ type: 'input.text', sessionId, text })); },
+    sendPromptResponse(sessionId, requestId, answers) {
+      ws?.send(JSON.stringify({ type: 'prompt-response', sessionId, requestId, answers }));
+    },
+    subscribeTerminal(sessionId, onMessage) {
+      let listeners = terminalListeners.get(sessionId);
+      if (!listeners) {
+        listeners = new Set();
+        terminalListeners.set(sessionId, listeners);
+      }
+      listeners.add(onMessage);
+      sendFrame({ type: 'terminal.subscribe', sessionId });
+      return () => {
+        const cur = terminalListeners.get(sessionId);
+        if (!cur) return;
+        cur.delete(onMessage);
+        if (cur.size === 0) {
+          terminalListeners.delete(sessionId);
+          sendFrame({ type: 'terminal.unsubscribe', sessionId });
+        }
+      };
+    },
+    close() {
+      ws?.close();
+      currentSocket = null;
+      terminalListeners.clear();
+    },
+  };
 }

--- a/packages/debug-web/src/ws-client.ts
+++ b/packages/debug-web/src/ws-client.ts
@@ -53,7 +53,12 @@ const terminalListeners = new Map<string, Set<(message: TerminalMessage) => void
 let currentSocket: WebSocket | null = null;
 
 function sendFrame(payload: object): void {
-  currentSocket?.send(JSON.stringify(payload));
+  // Only send when OPEN. While CONNECTING, ws.send throws InvalidStateError.
+  // Subscriptions issued before the socket opens are replayed via
+  // rehydrateTerminalSubscriptions() in the 'open' handler.
+  if (currentSocket && currentSocket.readyState === WebSocket.OPEN) {
+    currentSocket.send(JSON.stringify(payload));
+  }
 }
 
 function emitTerminal(message: TerminalMessage): void {
@@ -153,7 +158,12 @@ export function connect(): WsClient {
         terminalListeners.set(sessionId, listeners);
       }
       listeners.add(onMessage);
-      sendFrame({ type: 'terminal.subscribe', sessionId });
+      // Only ask the hub for a fresh snapshot the first time we register
+      // interest in this session. Subsequent listeners ride the existing
+      // subscription so we don't reset the live terminal view of the first.
+      if (listeners.size === 1) {
+        sendFrame({ type: 'terminal.subscribe', sessionId });
+      }
       return () => {
         const cur = terminalListeners.get(sessionId);
         if (!cur) return;

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@sesshin/shared": "workspace:*",
+    "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/headless": "^5.5.0",
     "ws": "^8.18.0",
     "pino": "^9.0.0",
     "zod": "^3.23.0"

--- a/packages/hub/src/observers/headless-term.ts
+++ b/packages/hub/src/observers/headless-term.ts
@@ -1,0 +1,50 @@
+import XtermHeadless from '@xterm/headless';
+import SerializeAddonPkg from '@xterm/addon-serialize';
+
+const { Terminal } = XtermHeadless as unknown as { Terminal: typeof import('@xterm/headless')['Terminal'] };
+const { SerializeAddon } = SerializeAddonPkg as unknown as { SerializeAddon: typeof import('@xterm/addon-serialize')['SerializeAddon'] };
+
+export interface HeadlessSnapshot {
+  cols: number;
+  rows: number;
+  data: string;
+}
+
+export class HeadlessTerm {
+  private readonly term: Terminal;
+  private readonly serializeAddon: SerializeAddon;
+
+  constructor(cols: number, rows: number) {
+    this.term = new Terminal({
+      cols,
+      rows,
+      allowProposedApi: true,
+      scrollback: 10_000,
+      convertEol: false,
+    });
+    this.serializeAddon = new SerializeAddon();
+    this.term.loadAddon(this.serializeAddon);
+  }
+
+  write(chunk: Buffer): void {
+    this.term.write(chunk);
+  }
+
+  resize(cols: number, rows: number): void {
+    if (cols <= 0 || rows <= 0) return;
+    if (this.term.cols === cols && this.term.rows === rows) return;
+    this.term.resize(cols, rows);
+  }
+
+  snapshot(): HeadlessSnapshot {
+    return {
+      cols: this.term.cols,
+      rows: this.term.rows,
+      data: this.serializeAddon.serialize(),
+    };
+  }
+
+  dispose(): void {
+    this.term.dispose();
+  }
+}

--- a/packages/hub/src/observers/headless-term.ts
+++ b/packages/hub/src/observers/headless-term.ts
@@ -1,18 +1,31 @@
 import XtermHeadless from '@xterm/headless';
 import SerializeAddonPkg from '@xterm/addon-serialize';
 
-const { Terminal } = XtermHeadless as unknown as { Terminal: typeof import('@xterm/headless')['Terminal'] };
-const { SerializeAddon } = SerializeAddonPkg as unknown as { SerializeAddon: typeof import('@xterm/addon-serialize')['SerializeAddon'] };
+type XtermTerminal = InstanceType<typeof import('@xterm/headless').Terminal>;
+type XtermSerializeAddon = InstanceType<typeof import('@xterm/addon-serialize').SerializeAddon>;
+
+const { Terminal } = XtermHeadless as unknown as {
+  Terminal: typeof import('@xterm/headless').Terminal;
+};
+const { SerializeAddon } = SerializeAddonPkg as unknown as {
+  SerializeAddon: typeof import('@xterm/addon-serialize').SerializeAddon;
+};
 
 export interface HeadlessSnapshot {
   cols: number;
   rows: number;
   data: string;
+  // seq corresponds to the last PtyTap chunk applied to this terminal. Captured
+  // alongside the serialize() result so callers don't poll currentSeq() and
+  // race against bytes that landed between snapshot serialization and the seq
+  // read.
+  seq: number;
 }
 
 export class HeadlessTerm {
-  private readonly term: Terminal;
-  private readonly serializeAddon: SerializeAddon;
+  private readonly term: XtermTerminal;
+  private readonly serializeAddon: XtermSerializeAddon;
+  private lastSeq = 0;
 
   constructor(cols: number, rows: number) {
     this.term = new Terminal({
@@ -26,8 +39,9 @@ export class HeadlessTerm {
     this.term.loadAddon(this.serializeAddon);
   }
 
-  write(chunk: Buffer): void {
+  write(chunk: Buffer, seq: number): void {
     this.term.write(chunk);
+    this.lastSeq = seq;
   }
 
   resize(cols: number, rows: number): void {
@@ -41,6 +55,7 @@ export class HeadlessTerm {
       cols: this.term.cols,
       rows: this.term.rows,
       data: this.serializeAddon.serialize(),
+      seq: this.lastSeq,
     };
   }
 

--- a/packages/hub/src/observers/pty-tap.ts
+++ b/packages/hub/src/observers/pty-tap.ts
@@ -38,6 +38,10 @@ export class PtyTap {
     return r.buf.slice(0, r.used);
   }
 
+  currentSeq(sessionId: string): number {
+    return this.rings.get(sessionId)?.seq ?? 0;
+  }
+
   subscribe(sessionId: string, sub: Subscriber): () => void {
     const r = this.ring(sessionId);
     r.subs.add(sub);

--- a/packages/hub/src/registry/session-registry.ts
+++ b/packages/hub/src/registry/session-registry.ts
@@ -8,6 +8,8 @@ export interface RegisterInput {
   cwd: string;
   pid: number;
   sessionFilePath: string;
+  cols?: number;
+  rows?: number;
 }
 
 function defaultSubstate(): Substate {
@@ -55,6 +57,8 @@ export class SessionRegistry extends EventEmitter {
       substate: defaultSubstate(),
       lastSummaryId: null,
       sessionFilePath: input.sessionFilePath,
+      cols: input.cols,
+      rows: input.rows,
       fileTailCursor: 0,
       lastHeartbeat: Date.now(),
       claudeAllowRules: [],
@@ -171,6 +175,17 @@ export class SessionRegistry extends EventEmitter {
     if (!s) return false;
     s.lastHeartbeat = Date.now();
     this.emit('substate-changed', this.publicView(s));
+    return true;
+  }
+
+  setSessionWinsize(id: string, cols: number, rows: number): boolean {
+    const s = this.sessions.get(id);
+    if (!s) return false;
+    if (cols <= 0 || rows <= 0) return false;
+    if (s.cols === cols && s.rows === rows) return true;
+    s.cols = cols;
+    s.rows = rows;
+    this.emit('config-changed', this.publicView(s));
     return true;
   }
 

--- a/packages/hub/src/registry/session-registry.ts
+++ b/packages/hub/src/registry/session-registry.ts
@@ -181,6 +181,7 @@ export class SessionRegistry extends EventEmitter {
   setSessionWinsize(id: string, cols: number, rows: number): boolean {
     const s = this.sessions.get(id);
     if (!s) return false;
+    if (!Number.isInteger(cols) || !Number.isInteger(rows)) return false;
     if (cols <= 0 || rows <= 0) return false;
     if (s.cols === cols && s.rows === rows) return true;
     s.cols = cols;

--- a/packages/hub/src/rest/server.ts
+++ b/packages/hub/src/rest/server.ts
@@ -41,6 +41,8 @@ export interface RestServerDeps {
   listClients?: (sessionId: string | null) => ClientInfo[];
   /** Read recent prompt-resolution history for a session, newest-first. */
   historyForSession?: (sessionId: string, n: number) => HistoryEntry[];
+  /** Update the PTY size reported by the CLI for a session. */
+  onWinsize?: (sessionId: string, cols: number, rows: number) => void;
   /**
    * Called from the stale-cleanup path when a tool-completion event
    * (PostToolUse / PostToolUseFailure / Stop) successfully resolves one or
@@ -65,9 +67,12 @@ const RegisterBody = z.object({
   cwd:                   z.string(),
   pid:                   z.number().int(),
   sessionFilePath:       z.string(),
+  cols:                  z.number().int().positive().optional(),
+  rows:                  z.number().int().positive().optional(),
   initialPermissionMode: PermissionModeEnum.optional(),
   claudeAllowRules:      z.array(z.string()).optional(),
 });
+const WinsizeBody = z.object({ cols: z.number().int().positive(), rows: z.number().int().positive() });
 
 const InjectBody = z.object({ data: z.string(), source: z.string() });
 
@@ -152,6 +157,19 @@ async function route(req: IncomingMessage, res: ServerResponse, deps: RestServer
     req.on('close', detach);
     res.on('close', detach);
     return;
+  }
+  const winsize = url.pathname.match(/^\/api\/sessions\/([^/]+)\/winsize$/);
+  if (winsize) {
+    const id = winsize[1]!;
+    if (method !== 'POST') return void res.writeHead(405).end();
+    if (!deps.registry.get(id)) return void res.writeHead(404).end();
+    let body: unknown;
+    try { body = await readJson(req); } catch { return void res.writeHead(400).end('bad json'); }
+    const parsed = WinsizeBody.safeParse(body);
+    if (!parsed.success) return void res.writeHead(400, { 'content-type': 'application/json' })
+                                 .end(JSON.stringify({ error: parsed.error.format() }));
+    deps.onWinsize?.(id, parsed.data.cols, parsed.data.rows);
+    return void res.writeHead(204).end();
   }
   const inj = url.pathname.match(/^\/api\/sessions\/([^/]+)\/inject$/);
   if (inj) {

--- a/packages/hub/src/wire.ts
+++ b/packages/hub/src/wire.ts
@@ -620,7 +620,7 @@ export async function startHub(): Promise<HubInstance> {
       const info = registry.get(sessionId);
       terminal = new HeadlessTerm(info?.cols ?? 80, info?.rows ?? 24);
       terminals.set(sessionId, terminal);
-      terminalTaps.set(sessionId, tap.subscribe(sessionId, (chunk) => terminal!.write(chunk)));
+      terminalTaps.set(sessionId, tap.subscribe(sessionId, (chunk, seq) => terminal!.write(chunk, seq)));
     }
     return terminal;
   };
@@ -637,7 +637,7 @@ export async function startHub(): Promise<HubInstance> {
       send({
         type: 'terminal.snapshot',
         sessionId,
-        seq: tap.currentSeq(sessionId),
+        seq: snap.seq,
         cols: snap.cols,
         rows: snap.rows,
         data: snap.data,
@@ -710,7 +710,10 @@ export async function startHub(): Promise<HubInstance> {
     shutdown: async () => {
       clearInterval(staleSweep);
       ptyIdleWatcher.stop();
-      for (const off of rawSubscriptions.values()) off();
+      for (const off of terminalTaps.values()) off();
+      terminalTaps.clear();
+      for (const t of terminals.values()) t.dispose();
+      terminals.clear();
       for (const s of stopTails.values()) s();
       checkpoint.stop();
       await ws.close();

--- a/packages/hub/src/wire.ts
+++ b/packages/hub/src/wire.ts
@@ -14,6 +14,7 @@ import { wirePtyIdleWatcher, type IdleWatcherConfig } from './observers/pty-idle
 import { wireStateMachine } from './state-machine/applier.js';
 import { Dedup } from './observers/dedup.js';
 import { PtyTap } from './observers/pty-tap.js';
+import { HeadlessTerm } from './observers/headless-term.js';
 import { tailSessionFile } from './observers/session-file-tail.js';
 import { createRestServer, type RestServer, type RestServerDeps } from './rest/server.js';
 import { createWsServer, type WsServerInstance, type WsServerDeps } from './ws/server.js';
@@ -596,6 +597,11 @@ export async function startHub(): Promise<HubInstance> {
     onDetachSink:    (id) => { bridge.clearSink(id); },
     approvals,
     hasSubscribedActionsClient: (sid) => wsRef?.hasSubscribedActionsClient(sid) ?? false,
+    onWinsize: (sessionId, cols, rows) => {
+      registry.setSessionWinsize(sessionId, cols, rows);
+      terminals.get(sessionId)?.resize(cols, rows);
+      wsRef?.broadcast({ type: 'terminal.resize', sessionId, cols, rows });
+    },
     listClients: (sid) => wsRef?.listClients(sid) ?? [],
     ...adapters.restDeps,
   });
@@ -606,11 +612,44 @@ export async function startHub(): Promise<HubInstance> {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname  = dirname(__filename);
   const staticDir  = join(__dirname, 'web');
+  const terminalTaps = new Map<string, () => void>();
+  const terminals = new Map<string, HeadlessTerm>();
+  const ensureTerminal = (sessionId: string): HeadlessTerm => {
+    let terminal = terminals.get(sessionId);
+    if (!terminal) {
+      const info = registry.get(sessionId);
+      terminal = new HeadlessTerm(info?.cols ?? 80, info?.rows ?? 24);
+      terminals.set(sessionId, terminal);
+      terminalTaps.set(sessionId, tap.subscribe(sessionId, (chunk) => terminal!.write(chunk)));
+    }
+    return terminal;
+  };
   const ws = createWsServer({
     registry, bus: dedupedBus, tap, staticDir, approvals,
     onInput: async (sessionId, data, source) => {
       const r = await bridge.deliver(sessionId, data, source);
       return { ok: r.ok, ...(r.reason !== undefined ? { reason: r.reason } : {}) };
+    },
+    onTerminalSubscribe: (sessionId, send) => {
+      if (!registry.get(sessionId)) return null;
+      const terminal = ensureTerminal(sessionId);
+      const snap = terminal.snapshot();
+      send({
+        type: 'terminal.snapshot',
+        sessionId,
+        seq: tap.currentSeq(sessionId),
+        cols: snap.cols,
+        rows: snap.rows,
+        data: snap.data,
+      });
+      return tap.subscribe(sessionId, (chunk, seq) => {
+        send({
+          type: 'terminal.delta',
+          sessionId,
+          seq,
+          data: chunk.toString('base64'),
+        });
+      });
     },
     ...adapters.wsDeps,
   });
@@ -620,27 +659,31 @@ export async function startHub(): Promise<HubInstance> {
 
   registry.on('session-removed', adapters.onSessionRemoved);
 
-  // Broadcast PTY raw output to WS clients with the `raw` capability.
-  const rawSubscriptions = new Map<string, () => void>();
-  const subscribeRaw = (sessionId: string): void => {
-    if (rawSubscriptions.has(sessionId)) return;
-    const off = tap.subscribe(sessionId, (chunk, seq) => {
-      ws.broadcast({
-        type: 'session.raw',
-        sessionId,
-        seq,
-        data: chunk.toString('utf-8'),
-      });
-    });
-    rawSubscriptions.set(sessionId, off);
-  };
-  const unsubscribeRaw = (sessionId: string): void => {
-    const off = rawSubscriptions.get(sessionId);
-    if (off) { off(); rawSubscriptions.delete(sessionId); }
-  };
-  registry.on('session-added', (info) => subscribeRaw(info.id));
-  registry.on('session-removed', (id) => unsubscribeRaw(id));
-  for (const s of registry.list()) subscribeRaw(s.id);
+  registry.on('session-added', (info) => ensureTerminal(info.id));
+  registry.on('session-removed', (id) => {
+    const off = terminalTaps.get(id);
+    if (off) off();
+    terminalTaps.delete(id);
+    terminals.get(id)?.dispose();
+    terminals.delete(id);
+    ws.broadcast({ type: 'terminal.ended', sessionId: id, reason: 'session-removed' });
+  });
+  for (const s of registry.list()) ensureTerminal(s.id);
+  registry.on('state-changed', (s) => {
+    if (s.state === 'done' || s.state === 'interrupted' || s.state === 'error') {
+      ws.broadcast({ type: 'terminal.ended', sessionId: s.id, reason: s.state });
+    }
+  });
+  registry.on('config-changed', (s) => {
+    if (s.cols && s.rows) {
+      terminals.get(s.id)?.resize(s.cols, s.rows);
+    }
+  });
+  registry.on('session-added', (s) => {
+    if (s.cols && s.rows) {
+      terminals.get(s.id)?.resize(s.cols, s.rows);
+    }
+  });
 
   // Summarizer trigger (T46): Stop → Mode B' → broadcast session.summary
   const useHeuristic = process.env['SESSHIN_SUMMARIZER'] === 'heuristic';

--- a/packages/hub/src/ws/connection.ts
+++ b/packages/hub/src/ws/connection.ts
@@ -94,7 +94,7 @@ export function handleConnection(
       ws.send(JSON.stringify({
         type: 'server.hello', protocol: PROTOCOL_VERSION,
         machine: hostname(),
-        supported: ['summary','events','raw','actions','voice','history','state','attention'],
+        supported: ['summary','events','terminal','actions','voice','history','state','attention'],
       }));
       attachSubscribed(state, deps);
       return;

--- a/packages/hub/src/ws/connection.ts
+++ b/packages/hub/src/ws/connection.ts
@@ -10,6 +10,7 @@ export interface ConnectionState {
   kind: string | null;
   capabilities: Set<string>;
   subscribedTo: Set<string> | 'all';
+  terminalSubscriptions: Map<string, () => void>;
 }
 
 export interface BroadcastTarget {
@@ -28,7 +29,13 @@ export function handleConnection(
   registerTarget: (target: BroadcastTarget) => void,
   bumpActions: (sessionId: string, delta: 1 | -1) => void,
 ): void {
-  const state: ConnectionState = { ws, kind: null, capabilities: new Set(), subscribedTo: new Set() };
+  const state: ConnectionState = {
+    ws,
+    kind: null,
+    capabilities: new Set(),
+    subscribedTo: new Set(),
+    terminalSubscriptions: new Map(),
+  };
   let identified = false;
   const identifyTimeout = setTimeout(() => {
     if (!identified) ws.close(1002, 'no client.identify within 5s');
@@ -53,6 +60,8 @@ export function handleConnection(
   // a now-departed client). Only relevant when this client had `actions` cap.
   ws.on('close', () => {
     detachAllListener();
+    for (const off of state.terminalSubscriptions.values()) off();
+    state.terminalSubscriptions.clear();
     if (!state.capabilities.has('actions')) return;
     // For 'all' subscribers, every session in the live registry was incremented
     // (originally on subscribe + via the session-added listener for any added
@@ -268,6 +277,34 @@ function handleUpstream(
       type: 'server.error', code: 'prompt-stale',
       message: 'no pending prompt-request for that requestId'
     }));
+    return;
+  }
+  if (msg.type === 'terminal.subscribe') {
+    if (!state.capabilities.has('terminal')) {
+      state.ws.send(JSON.stringify({ type: 'server.error', code: 'terminal-rejected', message: 'missing terminal capability' }));
+      return;
+    }
+    const existing = state.terminalSubscriptions.get(msg.sessionId);
+    if (existing) existing();
+    const send = (payload: object): void => {
+      state.ws.send(JSON.stringify(payload));
+    };
+    const off = deps.onTerminalSubscribe?.(msg.sessionId, send) ?? null;
+    if (!off) {
+      state.terminalSubscriptions.delete(msg.sessionId);
+      state.ws.send(JSON.stringify({ type: 'server.error', code: 'terminal-rejected', message: 'session-offline' }));
+      return;
+    }
+    state.terminalSubscriptions.set(msg.sessionId, off);
+    return;
+  }
+  if (msg.type === 'terminal.unsubscribe') {
+    const off = state.terminalSubscriptions.get(msg.sessionId);
+    if (off) {
+      off();
+      state.terminalSubscriptions.delete(msg.sessionId);
+    }
+    deps.onTerminalUnsubscribe?.(msg.sessionId, (payload) => state.ws.send(JSON.stringify(payload)));
     return;
   }
   if (msg.type === 'input.action' || msg.type === 'input.text') {

--- a/packages/hub/src/ws/server.ts
+++ b/packages/hub/src/ws/server.ts
@@ -7,6 +7,7 @@ import type { SessionRegistry } from '../registry/session-registry.js';
 import type { EventBus } from '../event-bus.js';
 import type { PtyTap } from '../observers/pty-tap.js';
 import type { ApprovalManager } from '../approval-manager.js';
+import type { HeadlessSnapshot } from '../observers/headless-term.js';
 import { handleConnection, type BroadcastTarget } from './connection.js';
 
 export interface WsServerDeps {
@@ -44,6 +45,9 @@ export interface WsServerDeps {
    * blocked on an absent remote.
    */
   onLastActionsClientGone?: (sessionId: string) => void;
+  onTerminalSubscribe?: (sessionId: string, send: (msg: object) => void) => (() => void) | null;
+  onTerminalUnsubscribe?: (sessionId: string, send: (msg: object) => void) => void;
+  getTerminalSnapshot?: (sessionId: string) => ({ seq: number } & HeadlessSnapshot) | null;
 }
 
 export interface WsServerInstance {
@@ -72,7 +76,10 @@ const MIME: Record<string, string> = {
 function capabilityRequiredFor(msgType: string): string | null {
   switch (msgType) {
     case 'session.summary':              return 'summary';
-    case 'session.raw':                  return 'raw';
+    case 'terminal.snapshot':
+    case 'terminal.delta':
+    case 'terminal.resize':
+    case 'terminal.ended':               return 'terminal';
     case 'session.event':                return 'events';
     case 'session.attention':            return 'attention';
     case 'session.prompt-request':

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -7,7 +7,7 @@ import { ActionEnum } from './actions.js';
 export const PROTOCOL_VERSION = 1 as const;
 
 export const ClientKindEnum = z.enum(['debug-web','telegram-adapter','m5stick','watch','mobile','other']);
-export const CapabilityEnum = z.enum(['summary','events','raw','actions','voice','history','state','attention']);
+export const CapabilityEnum = z.enum(['summary','events','terminal','actions','voice','history','state','attention']);
 
 // ---- Upstream (client → hub) ----
 export const ClientIdentifySchema = z.object({
@@ -27,6 +27,14 @@ export const SubscribeSchema = z.object({
 export const UnsubscribeSchema = z.object({
   type:     z.literal('unsubscribe'),
   sessions: z.array(z.string()),
+});
+export const TerminalSubscribeSchema = z.object({
+  type:      z.literal('terminal.subscribe'),
+  sessionId: z.string(),
+});
+export const TerminalUnsubscribeSchema = z.object({
+  type:      z.literal('terminal.unsubscribe'),
+  sessionId: z.string(),
 });
 export const InputTextSchema = z.object({
   type:      z.literal('input.text'),
@@ -77,6 +85,7 @@ export const PromptResponseSchema = z.object({
 
 export const UpstreamMessageSchema = z.discriminatedUnion('type', [
   ClientIdentifySchema, SubscribeSchema, UnsubscribeSchema,
+  TerminalSubscribeSchema, TerminalUnsubscribeSchema,
   InputTextSchema, InputActionSchema, ClientPongSchema,
   PromptResponseSchema,
 ]);
@@ -124,11 +133,30 @@ export const SessionAttentionSchema = z.object({
   reason:     z.string(),
   summaryId:  z.string().optional(),
 });
-export const SessionRawSchema = z.object({
-  type:      z.literal('session.raw'),
+export const TerminalSnapshotSchema = z.object({
+  type:      z.literal('terminal.snapshot'),
+  sessionId: z.string(),
+  seq:       z.number().int(),
+  cols:      z.number().int().positive(),
+  rows:      z.number().int().positive(),
+  data:      z.string(),
+});
+export const TerminalDeltaSchema = z.object({
+  type:      z.literal('terminal.delta'),
   sessionId: z.string(),
   seq:       z.number().int(),
   data:      z.string(),
+});
+export const TerminalResizeSchema = z.object({
+  type:      z.literal('terminal.resize'),
+  sessionId: z.string(),
+  cols:      z.number().int().positive(),
+  rows:      z.number().int().positive(),
+});
+export const TerminalEndedSchema = z.object({
+  type:      z.literal('terminal.ended'),
+  sessionId: z.string(),
+  reason:    z.string().nullable().optional(),
 });
 export const ServerErrorSchema = z.object({
   type:    z.literal('server.error'),
@@ -227,7 +255,8 @@ export const SessionChildChangedSchema = z.object({
 export const DownstreamMessageSchema = z.discriminatedUnion('type', [
   ServerHelloSchema, SessionListSchema, SessionAddedSchema, SessionRemovedSchema,
   SessionStateMsgSchema, SessionEventMsgSchema, SessionSummaryMsgSchema,
-  SessionAttentionSchema, SessionRawSchema, ServerErrorSchema, ServerPingSchema,
+  SessionAttentionSchema, TerminalSnapshotSchema, TerminalDeltaSchema,
+  TerminalResizeSchema, TerminalEndedSchema, ServerErrorSchema, ServerPingSchema,
   SessionPromptRequestSchema, SessionPromptRequestResolvedSchema,
   SessionConfigChangedSchema, SessionChildChangedSchema,
 ]);

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -62,6 +62,8 @@ export const SessionInfoSchema = z.object({
    * UIs can offer "open log" / "copy log path" affordances.
    */
   sessionFilePath: z.string().optional(),
+  cols:             z.number().int().positive().optional(),
+  rows:             z.number().int().positive().optional(),
   // Sticky user-set session config. All three are nullable+optional:
   // - missing: schema-level backwards compatibility for old payloads
   // - null:    explicitly unset (default after register())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
       '@sesshin/shared':
         specifier: workspace:*
         version: link:../shared
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       preact:
         specifier: ^10.24.0
         version: 10.29.1
@@ -95,6 +101,12 @@ importers:
       '@sesshin/shared':
         specifier: workspace:*
         version: link:../shared
+      '@xterm/addon-serialize':
+        specifier: ^0.13.0
+        version: 0.13.0(@xterm/xterm@5.5.0)
+      '@xterm/headless':
+        specifier: ^5.5.0
+        version: 5.5.0
       pino:
         specifier: ^9.0.0
         version: 9.14.0
@@ -818,6 +830,22 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-serialize@0.13.0':
+    resolution: {integrity: sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/headless@5.5.0':
+    resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -2126,6 +2154,18 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-serialize@0.13.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/headless@5.5.0': {}
+
+  '@xterm/xterm@5.5.0': {}
 
   abbrev@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- replace debug-web's raw `<pre>` terminal dump with xterm.js rendering in a dedicated Terminal tab
- add hub-side headless terminal snapshots/deltas plus PTY winsize propagation so late joins reconstruct the current Claude TUI screen
- fix CLI PTY tap reconnect queue draining and add a local relink script for `sesshin` / `sesshin-hub`

## Test plan
- [x] pnpm --filter @sesshin/shared test
- [x] pnpm --filter @sesshin/cli test
- [x] pnpm --filter @sesshin/hub test
- [x] pnpm --filter @sesshin/debug-web test
- [x] pnpm --filter @sesshin/cli build
- [x] pnpm --filter @sesshin/hub build
- [x] pnpm --filter @sesshin/debug-web build
- [x] start hub and confirm `GET /api/health` returns `{\"ok\":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live terminal streaming in the debug web UI with a Terminal tab and tabbed session view
  * Terminal theme selection and custom JSON themes with persisted preferences
  * Real-time terminal resizing reflected across clients

* **Refactor**
  * More resilient terminal streaming with automatic reconnect, buffering, and backoff

* **Chores**
  * New CLI install/build/link script

* **Tests**
  * Added tests for terminal streaming and PTY behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->