### PR TITLE
feat: statusline-driven rate-limit readout

### DIFF
--- a/docs/superpowers/plans/2026-05-07-statusline-rate-limits.md
+++ b/docs/superpowers/plans/2026-05-07-statusline-rate-limits.md
@@ -1,0 +1,1602 @@
+# Statusline Rate-Limit Readout — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture Claude Code's account-level 5h/7d quota state from the statusline JSON channel, expose it to debug-web (and future remote clients) as a header pill, while preserving any user-configured original statusline.
+
+**Architecture:** A new lean bin in `@sesshin/cli` (`sesshin-statusline-relay`, ~3 KB) is injected into Claude Code's `--settings` as the `statusLine.command`. On each render it reads CC's stdin JSON, fire-and-forgets a POST to the existing hub at `/reports/rate-limits`, then spawns the user's resolved original statusline (passed via env var) and forwards its output. The hub stores `RateLimitsState` per session and broadcasts a new `session.rate-limits` WS message; debug-web's store dispatches it onto a Zustand slice rendered as an inline pill in the existing `SessionDetail` header. See spec at `docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md`.
+
+**Tech Stack:** TypeScript (Node 22 / ESM), pnpm workspaces, tsup, vitest, Zod, native `node:http`, `node-pty`, React 18 + Zustand (debug-web).
+
+---
+
+## File map (drives the task ordering below)
+
+| File | New / Modify | Purpose |
+|---|---|---|
+| `packages/shared/src/protocol.ts` | Modify | Zod schemas + types for `RateLimitWindow`, `RateLimitsState`, `SessionRateLimits` |
+| `packages/hub/src/registry/session-registry.ts` | Modify | `rateLimits` field on `SessionRecord` + `setRateLimits` / `getRateLimits` methods |
+| `packages/hub/src/registry/session-registry.test.ts` | Modify | Cover the new field/methods |
+| `packages/hub/src/rest/server.ts` | Modify | `onRateLimitReport` callback, `POST /reports/rate-limits` route |
+| `packages/hub/src/rest/server.test.ts` | Modify | 204 / 400 / 404 cases |
+| `packages/hub/src/wire.ts` | Modify | Wire registry update + WS broadcast on rate-limit report |
+| `packages/hub/src/wire.test.ts` | Modify | End-to-end POST → registry → broadcast assertion |
+| `packages/hub/src/ws/connection.ts` | Modify | Include current rate-limits in subscribe-replay frames |
+| `packages/hub/src/ws/connection.test.ts` | Modify | Cover the replay inclusion |
+| `packages/cli/src/read-claude-settings.ts` | Modify | `resolveInheritedStatusLine(opts)` helper |
+| `packages/cli/src/read-claude-settings.test.ts` | Modify | Three cases for the new helper |
+| `packages/cli/src/statusline-relay/relay.ts` | New | Pure-logic relay (DI for fetch/spawn/streams) |
+| `packages/cli/src/statusline-relay/relay.test.ts` | New | Eight edge-case tests |
+| `packages/cli/src/statusline-relay/index.ts` | New | Entry plumbing real env/streams/fetch/spawn |
+| `packages/cli/bin/sesshin-statusline-relay` | New | 4-line node shim |
+| `packages/cli/tsup.config.ts` | Modify | Second entry for the relay |
+| `packages/cli/package.json` | Modify | Second `bin` entry |
+| `packages/cli/src/settings-merge.ts` | Modify | Inject our statusLine unless opt-out env set |
+| `packages/cli/src/settings-merge.test.ts` | Modify | Inject + opt-out cases |
+| `packages/cli/src/claude.ts` | Modify | Resolve user statusline + propagate via env |
+| `packages/cli/src/claude.test.ts` (or sibling) | New/Modify | Cover the env propagation |
+| `packages/debug-web/src/store.ts` | Modify | `rateLimits` slice + WS dispatch |
+| `packages/debug-web/src/store.test.ts` | Modify | Dispatch + replay-hydration cases |
+| `packages/debug-web/src/components/RateLimitsPill.tsx` | New | Component with render-state matrix + countdown |
+| `packages/debug-web/src/components/RateLimitsPill.test.tsx` | New | Render-state matrix + color + tick |
+| `packages/debug-web/src/components/SessionDetail.tsx` | Modify | Mount the pill inline in the header row |
+
+---
+
+## Task 1: Shared protocol schemas
+
+**Files:**
+- Modify: `packages/shared/src/protocol.ts`
+- Test: same file or `packages/shared/src/protocol.test.ts` (whichever is conventional in the package — both exist for sibling schemas)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/shared/src/protocol.test.ts` (create if absent — match the file-naming used for adjacent schema tests):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { RateLimitWindowSchema, RateLimitsStateSchema, SessionRateLimitsSchema } from './protocol.js';
+
+describe('RateLimitWindowSchema', () => {
+  it('parses a well-formed window', () => {
+    const r = RateLimitWindowSchema.parse({ used_percentage: 45.2, resets_at: 1714867200 });
+    expect(r).toEqual({ used_percentage: 45.2, resets_at: 1714867200 });
+  });
+  it('rejects when fields are missing', () => {
+    expect(() => RateLimitWindowSchema.parse({ used_percentage: 1 })).toThrow();
+  });
+});
+
+describe('RateLimitsStateSchema', () => {
+  it('parses null windows (API-key user)', () => {
+    const r = RateLimitsStateSchema.parse({ five_hour: null, seven_day: null, observed_at: 1 });
+    expect(r.five_hour).toBeNull();
+    expect(r.seven_day).toBeNull();
+  });
+  it('parses both windows present', () => {
+    const r = RateLimitsStateSchema.parse({
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: { used_percentage: 23, resets_at: 200 },
+      observed_at: 999,
+    });
+    expect(r.five_hour?.used_percentage).toBe(45);
+    expect(r.observed_at).toBe(999);
+  });
+});
+
+describe('SessionRateLimitsSchema', () => {
+  it('parses a valid broadcast envelope', () => {
+    const m = SessionRateLimitsSchema.parse({
+      type: 'session.rate-limits',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: null, observed_at: 1 },
+    });
+    expect(m.type).toBe('session.rate-limits');
+    expect(m.sessionId).toBe('s1');
+  });
+  it('rejects wrong type literal', () => {
+    expect(() => SessionRateLimitsSchema.parse({
+      type: 'session.something-else',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: null, observed_at: 1 },
+    })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+pnpm --filter @sesshin/shared test -- protocol
+```
+
+Expected: failures referencing missing exports `RateLimitWindowSchema`, `RateLimitsStateSchema`, `SessionRateLimitsSchema`.
+
+- [ ] **Step 3: Add the schemas to `packages/shared/src/protocol.ts`**
+
+Append (after the existing schemas, before the type exports block):
+
+```ts
+export const RateLimitWindowSchema = z.object({
+  used_percentage: z.number(),
+  resets_at:       z.number(),
+});
+
+export const RateLimitsStateSchema = z.object({
+  five_hour:    RateLimitWindowSchema.nullable(),
+  seven_day:    RateLimitWindowSchema.nullable(),
+  observed_at:  z.number(),
+});
+
+export const SessionRateLimitsSchema = z.object({
+  type:        z.literal('session.rate-limits'),
+  sessionId:   z.string(),
+  rateLimits:  RateLimitsStateSchema,
+});
+
+export type RateLimitWindow   = z.infer<typeof RateLimitWindowSchema>;
+export type RateLimitsState   = z.infer<typeof RateLimitsStateSchema>;
+export type SessionRateLimits = z.infer<typeof SessionRateLimitsSchema>;
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+```bash
+pnpm --filter @sesshin/shared test -- protocol
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/protocol.ts packages/shared/src/protocol.test.ts
+git commit -m "feat(shared): add rate-limit window/state/broadcast schemas"
+```
+
+---
+
+## Task 2: Registry — per-session rate-limits slot
+
+**Files:**
+- Modify: `packages/hub/src/registry/session-registry.ts`
+- Test: `packages/hub/src/registry/session-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `session-registry.test.ts`:
+
+```ts
+import type { RateLimitsState } from '@sesshin/shared';
+
+describe('rateLimits', () => {
+  it('returns null before any setRateLimits call', () => {
+    const reg = new SessionRegistry();
+    reg.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    expect(reg.getRateLimits('s1')).toBeNull();
+  });
+
+  it('round-trips a state via setRateLimits / getRateLimits', () => {
+    const reg = new SessionRegistry();
+    reg.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    const state: RateLimitsState = {
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: null,
+      observed_at: 999,
+    };
+    reg.setRateLimits('s1', state);
+    expect(reg.getRateLimits('s1')).toEqual(state);
+  });
+
+  it('setRateLimits on unknown session is a no-op (returns false)', () => {
+    const reg = new SessionRegistry();
+    expect(reg.setRateLimits('missing', { five_hour: null, seven_day: null, observed_at: 1 })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/hub test -- session-registry
+```
+
+Expected: failures on `getRateLimits` / `setRateLimits` not existing.
+
+- [ ] **Step 3: Implement in `session-registry.ts`**
+
+Add `rateLimits` to `SessionRecord` interface (after `quietUntil`):
+
+```ts
+export interface SessionRecord extends SessionInfo {
+  // ... existing fields ...
+  pin: string | null;
+  quietUntil: number | null;
+  rateLimits: RateLimitsState | null;
+}
+```
+
+In `register()`, initialize the new field:
+
+```ts
+    rateLimits: null,
+```
+
+Add the import at the top:
+
+```ts
+import type { RateLimitsState } from '@sesshin/shared';
+```
+
+Add the two methods to the class (place near other getters/setters, e.g. after the `quietUntil` accessors):
+
+```ts
+  setRateLimits(id: string, state: RateLimitsState): boolean {
+    const s = this.sessions.get(id);
+    if (!s) return false;
+    s.rateLimits = state;
+    return true;
+  }
+
+  getRateLimits(id: string): RateLimitsState | null {
+    return this.sessions.get(id)?.rateLimits ?? null;
+  }
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/hub test -- session-registry
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/registry/session-registry.ts packages/hub/src/registry/session-registry.test.ts
+git commit -m "feat(hub): add rateLimits slot to SessionRecord"
+```
+
+---
+
+## Task 3: Hub REST endpoint `POST /reports/rate-limits`
+
+**Files:**
+- Modify: `packages/hub/src/rest/server.ts`
+- Test: `packages/hub/src/rest/server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `describe` block in `server.test.ts`. Match the existing test scaffolding pattern in the file for spinning up the server with fake deps; the snippet below assumes a test-helper named `startTestServer` already exists (it does — see how `'/hooks'` tests build the server). Adapt the helper name if local conventions differ.
+
+```ts
+describe('POST /reports/rate-limits', () => {
+  it('returns 404 when sessionId is unknown', async () => {
+    const reports: any[] = [];
+    const { url, close } = await startTestServer({
+      onRateLimitReport: (env) => { reports.push(env); },
+      // registry has no session 'missing'
+    });
+    try {
+      const r = await fetch(`${url}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'missing', five_hour: null, seven_day: null }),
+      });
+      expect(r.status).toBe(404);
+      expect(reports).toEqual([]);
+    } finally { await close(); }
+  });
+
+  it('returns 400 on a malformed body', async () => {
+    const reports: any[] = [];
+    const { url, registry, close } = await startTestServer({
+      onRateLimitReport: (env) => { reports.push(env); },
+    });
+    registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    try {
+      const r = await fetch(`${url}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's1', five_hour: 'not-an-object', seven_day: null }),
+      });
+      expect(r.status).toBe(400);
+      expect(reports).toEqual([]);
+    } finally { await close(); }
+  });
+
+  it('returns 204 + invokes onRateLimitReport on a valid body', async () => {
+    const reports: any[] = [];
+    const { url, registry, close } = await startTestServer({
+      onRateLimitReport: (env) => { reports.push(env); },
+    });
+    registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    try {
+      const body = {
+        sessionId: 's1',
+        five_hour: { used_percentage: 45, resets_at: 100 },
+        seven_day: null,
+      };
+      const r = await fetch(`${url}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      expect(r.status).toBe(204);
+      expect(reports).toHaveLength(1);
+      expect(reports[0].sessionId).toBe('s1');
+      expect(reports[0].state.five_hour).toEqual({ used_percentage: 45, resets_at: 100 });
+      expect(reports[0].state.seven_day).toBeNull();
+      expect(typeof reports[0].state.observed_at).toBe('number');
+    } finally { await close(); }
+  });
+});
+```
+
+If `startTestServer` does not yet support `onRateLimitReport`, extend its options object first to forward it into `RestServerDeps`.
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/hub test -- rest/server
+```
+
+Expected: 404 path may already exist (default no-route); 204 path will fail because the route doesn't exist yet.
+
+- [ ] **Step 3: Implement the route + dep callback**
+
+In `packages/hub/src/rest/server.ts`:
+
+(a) Add to `RestServerDeps`:
+
+```ts
+  /** Fired when a rate-limit report arrives via POST /reports/rate-limits. */
+  onRateLimitReport?: (env: { sessionId: string; state: RateLimitsState }) => void;
+```
+
+(b) Add an import:
+
+```ts
+import { RateLimitsStateSchema, type RateLimitsState } from '@sesshin/shared';
+```
+
+(c) Define the request schema near the existing schemas (e.g. near `RegisterBody`):
+
+```ts
+const RateLimitReportBody = z.object({
+  sessionId:  z.string(),
+  five_hour:  RateLimitsStateSchema.shape.five_hour,
+  seven_day:  RateLimitsStateSchema.shape.seven_day,
+});
+```
+
+(d) Add the route handler. Place it near the `/hooks` block (~ line 228):
+
+```ts
+  if (url.pathname === '/reports/rate-limits') {
+    if (method !== 'POST') {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+    const raw = await readJsonBody(req);
+    const parsed = RateLimitReportBody.safeParse(raw);
+    if (!parsed.success) {
+      res.statusCode = 400;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'invalid body', issues: parsed.error.issues }));
+      return;
+    }
+    if (!deps.registry.get(parsed.data.sessionId)) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    const state: RateLimitsState = {
+      five_hour:   parsed.data.five_hour,
+      seven_day:   parsed.data.seven_day,
+      observed_at: Date.now(),
+    };
+    deps.onRateLimitReport?.({ sessionId: parsed.data.sessionId, state });
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+```
+
+(`readJsonBody` is the same helper already used by the `/hooks` handler — reuse it.)
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/hub test -- rest/server
+```
+
+Expected: PASS for all three cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/rest/server.ts packages/hub/src/rest/server.test.ts
+git commit -m "feat(hub): POST /reports/rate-limits intake"
+```
+
+---
+
+## Task 4: Wire registry update + WS broadcast on rate-limit report
+
+**Files:**
+- Modify: `packages/hub/src/wire.ts`
+- Test: `packages/hub/src/wire.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `wire.test.ts`. The existing tests already build a wired hub via a helper (`buildWiredHub` or similar — match the existing convention):
+
+```ts
+describe('rate-limit report wiring', () => {
+  it('stores in registry and broadcasts session.rate-limits', async () => {
+    const { onRateLimitReport, registry, ws } = buildWiredHub();
+    registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    const broadcasts: any[] = [];
+    ws.broadcast = (m: any) => broadcasts.push(m);
+
+    onRateLimitReport!({
+      sessionId: 's1',
+      state: { five_hour: { used_percentage: 45, resets_at: 100 }, seven_day: null, observed_at: 999 },
+    });
+
+    expect(registry.getRateLimits('s1')?.five_hour?.used_percentage).toBe(45);
+    expect(broadcasts).toHaveLength(1);
+    expect(broadcasts[0]).toMatchObject({
+      type: 'session.rate-limits',
+      sessionId: 's1',
+      rateLimits: { five_hour: { used_percentage: 45 } },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/hub test -- wire
+```
+
+Expected: FAIL — `onRateLimitReport` is not exposed by `buildWiredHub` yet.
+
+- [ ] **Step 3: Implement the wire**
+
+In `packages/hub/src/wire.ts`, locate where `RestServerDeps` is constructed for the REST server. Add the callback:
+
+```ts
+const deps: RestServerDeps = {
+  // ... existing fields ...
+  onRateLimitReport: ({ sessionId, state }) => {
+    if (!registry.setRateLimits(sessionId, state)) return;
+    getWs()?.broadcast({
+      type: 'session.rate-limits',
+      sessionId,
+      rateLimits: state,
+    });
+  },
+};
+```
+
+If `wire.ts` exposes a return shape used by tests, also expose the callback so the test can poke it directly without spinning up a real HTTP server. Otherwise, the test should call through HTTP (in which case adapt the test to do so).
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/hub test -- wire
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/wire.ts packages/hub/src/wire.test.ts
+git commit -m "feat(hub): wire rate-limit report → registry + WS broadcast"
+```
+
+---
+
+## Task 5: Subscribe-replay includes current rate limits
+
+**Files:**
+- Modify: `packages/hub/src/ws/connection.ts`
+- Test: `packages/hub/src/ws/connection.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `connection.test.ts` (alongside the existing replay-frame tests):
+
+```ts
+it('replay includes session.rate-limits when state exists', async () => {
+  const { client, registry } = await startWsClientWithSubscription();
+  registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+  registry.setRateLimits('s1', { five_hour: { used_percentage: 30, resets_at: 200 }, seven_day: null, observed_at: 1 });
+
+  const replayed = await client.subscribeAndCollectReplay('s1');
+  const rl = replayed.find((m: any) => m.type === 'session.rate-limits');
+  expect(rl).toBeDefined();
+  expect(rl.rateLimits.five_hour.used_percentage).toBe(30);
+});
+
+it('replay omits session.rate-limits when state is null', async () => {
+  const { client, registry } = await startWsClientWithSubscription();
+  registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+  // no setRateLimits call
+
+  const replayed = await client.subscribeAndCollectReplay('s1');
+  expect(replayed.some((m: any) => m.type === 'session.rate-limits')).toBe(false);
+});
+```
+
+If the test helper `subscribeAndCollectReplay` does not exist, extend the existing replay test scaffolding to support collecting the full replay frame (look at how `'replay frame is structurally identical to a hand-built live broadcast'` builds its expected shape — line ~300 of the file).
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/hub test -- ws/connection
+```
+
+Expected: FAIL — the replay frame does not yet include rate-limits.
+
+- [ ] **Step 3: Implement in `connection.ts`**
+
+Locate the subscribe-replay code (it builds and sends each `session.*` frame for the subscribed session). Add, after the existing per-session emissions:
+
+```ts
+const rl = registry.getRateLimits(sessionId);
+if (rl) {
+  send({
+    type: 'session.rate-limits',
+    sessionId,
+    rateLimits: rl,
+  });
+}
+```
+
+The `registry` and `send` (or the equivalent function name in this scope — likely `socket.send` after JSON.stringify) names must match what the surrounding code uses; do not invent new ones.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/hub test -- ws/connection
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/ws/connection.ts packages/hub/src/ws/connection.test.ts
+git commit -m "feat(hub): include rate-limits in subscribe-replay"
+```
+
+---
+
+## Task 6: `resolveInheritedStatusLine` helper
+
+**Files:**
+- Modify: `packages/cli/src/read-claude-settings.ts`
+- Test: `packages/cli/src/read-claude-settings.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `read-claude-settings.test.ts`:
+
+```ts
+import { resolveInheritedStatusLine } from './read-claude-settings.js';
+
+describe('resolveInheritedStatusLine', () => {
+  it('returns null when no settings file has a statusLine', () => {
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD })).toBeNull();
+  });
+
+  it('returns user-level statusLine when only ~/.claude/settings.json has one', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'my-statusline' },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD }))
+      .toEqual({ command: 'my-statusline' });
+  });
+
+  it('project-level statusLine wins over user-level', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    mkdirSync(join(CWD, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'user-cmd' },
+    }));
+    writeFileSync(join(CWD, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'project-cmd', padding: 1 },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD }))
+      .toEqual({ command: 'project-cmd', padding: 1 });
+  });
+
+  it('skips the excluded settings path even if it has a statusLine', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    const tmpInjected = join(CWD, 'sesshin-injected.json');
+    writeFileSync(tmpInjected, JSON.stringify({
+      statusLine: { type: 'command', command: 'sesshin-relay' },
+    }));
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'user-cmd' },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD, excludePath: tmpInjected }))
+      .toEqual({ command: 'user-cmd' });
+  });
+
+  it('ignores statusLine entries whose type is not "command"', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'static', value: 'hi' } as unknown,
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/cli test -- read-claude-settings
+```
+
+Expected: FAIL on `resolveInheritedStatusLine` not exported.
+
+- [ ] **Step 3: Implement in `read-claude-settings.ts`**
+
+Add (export it):
+
+```ts
+export interface ResolveStatusLineOpts {
+  home: string;
+  cwd: string;
+  /** Absolute path of a settings file to skip in the inheritance walk
+   *  (used to omit our own injected --settings temp file). */
+  excludePath?: string;
+}
+
+export interface InheritedStatusLine {
+  command: string;
+  padding?: number;
+}
+
+export function resolveInheritedStatusLine(opts: ResolveStatusLineOpts): InheritedStatusLine | null {
+  const candidates: string[] = [
+    '/etc/claude/settings.json',                                  // enterprise
+    join(opts.cwd,  '.claude/settings.local.json'),               // project (local)
+    join(opts.cwd,  '.claude/settings.json'),                     // project
+    join(opts.home, '.claude/settings.json'),                     // user
+  ];
+  // Highest precedence first per CC's resolution order.
+  for (const path of candidates) {
+    if (opts.excludePath && path === opts.excludePath) continue;
+    const sl = readStatusLineFromFile(path);
+    if (sl) return sl;
+  }
+  return null;
+}
+
+function readStatusLineFromFile(path: string): InheritedStatusLine | null {
+  let raw: string;
+  try { raw = readFileSync(path, 'utf-8'); } catch { return null; }
+  let parsed: any;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  const sl = parsed?.statusLine;
+  if (!sl || sl.type !== 'command' || typeof sl.command !== 'string') return null;
+  const out: InheritedStatusLine = { command: sl.command };
+  if (typeof sl.padding === 'number') out.padding = sl.padding;
+  return out;
+}
+```
+
+Add `import { readFileSync } from 'node:fs';` and `import { join } from 'node:path';` if not already imported in this file.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/cli test -- read-claude-settings
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/read-claude-settings.ts packages/cli/src/read-claude-settings.test.ts
+git commit -m "feat(cli): resolveInheritedStatusLine for wrap-mode statusline"
+```
+
+---
+
+## Task 7: Relay pure-logic module
+
+**Files:**
+- Create: `packages/cli/src/statusline-relay/relay.ts`
+- Create: `packages/cli/src/statusline-relay/relay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/src/statusline-relay/relay.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { runRelay, type RelayDeps } from './relay.js';
+
+function makeDeps(overrides: Partial<RelayDeps> = {}): RelayDeps {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const fetched: any[] = [];
+  return {
+    stdin: '{}',
+    stdout: { write: (s: string) => { stdout.push(s); return true; } },
+    stderr: { write: (s: string) => { stderr.push(s); return true; } },
+    env: { SESSHIN_HUB_URL: 'http://127.0.0.1:9663', SESSHIN_SESSION_ID: 's1' },
+    fetch: async (url: string, init?: any) => {
+      fetched.push({ url, init });
+      return new Response(null, { status: 204 });
+    },
+    spawn: () => { throw new Error('spawn should not be called when SESSHIN_USER_STATUSLINE_CMD is unset'); },
+    fastTimeoutMs: 250,
+    wrapTimeoutMs: 1500,
+    ...overrides,
+    // Re-attach captures so test can assert
+    _captured: { stdout, stderr, fetched },
+  } as any;
+}
+
+describe('runRelay', () => {
+  it('POSTs null windows when rate_limits absent and renders nothing (no wrap)', async () => {
+    const deps = makeDeps({ stdin: '{"model":"claude-opus","other":1}' });
+    const code = await runRelay(deps);
+    expect(code).toBe(0);
+    expect((deps as any)._captured.fetched[0].init.body)
+      .toBe(JSON.stringify({ sessionId: 's1', five_hour: null, seven_day: null }));
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+  });
+
+  it('POSTs both windows when rate_limits present and renders default', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({
+        rate_limits: {
+          five_hour: { used_percentage: 45, resets_at: 100 },
+          seven_day: { used_percentage: 23, resets_at: 200 },
+        },
+      }),
+    });
+    const code = await runRelay(deps);
+    expect(code).toBe(0);
+    const body = JSON.parse((deps as any)._captured.fetched[0].init.body);
+    expect(body.five_hour.used_percentage).toBe(45);
+    expect(body.seven_day.used_percentage).toBe(23);
+    expect((deps as any)._captured.stdout.join('')).toBe('5h: 45% · 7d: 23%');
+  });
+
+  it('renders empty when rate_limits absent and no wrap configured', async () => {
+    const deps = makeDeps({ stdin: '{}' });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+    expect(code).toBe(0);
+  });
+
+  it('partially-present rate_limits POSTs nulls for missing windows', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({ rate_limits: { five_hour: { used_percentage: 1, resets_at: 1 } } }),
+    });
+    await runRelay(deps);
+    const body = JSON.parse((deps as any)._captured.fetched[0].init.body);
+    expect(body.five_hour).toEqual({ used_percentage: 1, resets_at: 1 });
+    expect(body.seven_day).toBeNull();
+  });
+
+  it('malformed stdin JSON: skips POST, runs wrap if configured, exits 0', async () => {
+    const spawnCalls: any[] = [];
+    const deps = makeDeps({
+      stdin: 'not json',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'echo wrapped' },
+      spawn: ((cmd: string, args: string[], opts: any) => {
+        spawnCalls.push({ cmd, args, opts });
+        return Promise.resolve({ code: 0, stdout: 'wrapped', stderr: '' });
+      }) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.fetched).toEqual([]);
+    expect((deps as any)._captured.stdout.join('')).toBe('wrapped');
+    expect(spawnCalls[0].args).toEqual(['-c', 'echo wrapped']);
+    expect(code).toBe(0);
+  });
+
+  it('hub unreachable: POST aborts, wrap still runs, exits 0', async () => {
+    const deps = makeDeps({
+      stdin: '{}',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'cat' },
+      fetch: async () => { throw new Error('connection refused'); },
+      spawn: ((_cmd: string, _args: string[], opts: any) => {
+        return Promise.resolve({ code: 0, stdout: 'ok-' + opts.stdin, stderr: '' });
+      }) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('ok-{}');
+    expect(code).toBe(0);
+  });
+
+  it('wrap command non-zero exit: falls back to default render, logs to stderr', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({ rate_limits: { five_hour: { used_percentage: 10, resets_at: 1 }, seven_day: null } }),
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'broken' },
+      spawn: (() => Promise.resolve({ code: 1, stdout: '', stderr: 'boom' })) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('5h: 10% · 7d: -');
+    expect((deps as any)._captured.stderr.join('')).toMatch(/sesshin-statusline-relay: wrapped command exited 1/);
+    expect(code).toBe(0);
+  });
+
+  it('wrap command times out: kills, falls back to default, exits 0', async () => {
+    const deps = makeDeps({
+      stdin: '{}',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'sleep 99' },
+      spawn: (() => Promise.resolve({ code: null, stdout: '', stderr: '', timedOut: true })) as any,
+      wrapTimeoutMs: 5,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+    expect((deps as any)._captured.stderr.join('')).toMatch(/timed out/);
+    expect(code).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/cli test -- statusline-relay
+```
+
+Expected: FAIL — module does not exist yet.
+
+- [ ] **Step 3: Implement in `relay.ts`**
+
+```ts
+export interface RelayDeps {
+  stdin: string;
+  stdout: { write: (s: string) => boolean | void };
+  stderr: { write: (s: string) => boolean | void };
+  env: {
+    SESSHIN_HUB_URL?: string;
+    SESSHIN_SESSION_ID?: string;
+    SESSHIN_USER_STATUSLINE_CMD?: string;
+    SESSHIN_USER_STATUSLINE_PADDING?: string;
+  };
+  fetch: typeof globalThis.fetch;
+  spawn: (
+    cmd: string,
+    args: string[],
+    opts: { stdin: string; timeoutMs: number },
+  ) => Promise<{ code: number | null; stdout: string; stderr: string; timedOut?: boolean }>;
+  fastTimeoutMs: number;
+  wrapTimeoutMs: number;
+}
+
+interface RateLimitWindow { used_percentage: number; resets_at: number; }
+interface RateLimitsPayload { five_hour: RateLimitWindow | null; seven_day: RateLimitWindow | null; }
+
+export async function runRelay(deps: RelayDeps): Promise<number> {
+  // 1. Parse stdin (best-effort)
+  let parsed: any = null;
+  let parseOk = false;
+  try { parsed = JSON.parse(deps.stdin); parseOk = true; } catch { /* keep null */ }
+
+  // 2. Extract rate_limits → payload (or skip POST if parse failed)
+  let payload: RateLimitsPayload | null = null;
+  if (parseOk) {
+    const r = parsed?.rate_limits ?? {};
+    payload = {
+      five_hour: extractWindow(r?.five_hour),
+      seven_day: extractWindow(r?.seven_day),
+    };
+  }
+
+  // 3. Fire-and-forget POST (await, but bounded)
+  if (payload && deps.env.SESSHIN_HUB_URL && deps.env.SESSHIN_SESSION_ID) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), deps.fastTimeoutMs);
+    try {
+      await deps.fetch(`${deps.env.SESSHIN_HUB_URL}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: deps.env.SESSHIN_SESSION_ID, ...payload }),
+        signal: controller.signal,
+      });
+    } catch { /* swallow */ }
+    finally { clearTimeout(timer); }
+  }
+
+  // 4. Wrap user's statusline if configured
+  const userCmd = deps.env.SESSHIN_USER_STATUSLINE_CMD;
+  if (userCmd && userCmd.trim().length > 0) {
+    const r = await deps.spawn('sh', ['-c', userCmd], { stdin: deps.stdin, timeoutMs: deps.wrapTimeoutMs });
+    if (r.timedOut) {
+      deps.stderr.write(`sesshin-statusline-relay: wrapped command timed out after ${deps.wrapTimeoutMs}ms\n`);
+      deps.stdout.write(defaultRender(payload));
+      return 0;
+    }
+    if (r.code !== 0) {
+      deps.stderr.write(`sesshin-statusline-relay: wrapped command exited ${r.code}\n`);
+      deps.stdout.write(defaultRender(payload));
+      return 0;
+    }
+    deps.stdout.write(r.stdout);
+    return 0;
+  }
+
+  // 5. Default render
+  deps.stdout.write(defaultRender(payload));
+  return 0;
+}
+
+function extractWindow(w: any): RateLimitWindow | null {
+  if (!w || typeof w !== 'object') return null;
+  if (typeof w.used_percentage !== 'number' || typeof w.resets_at !== 'number') return null;
+  return { used_percentage: w.used_percentage, resets_at: w.resets_at };
+}
+
+function defaultRender(payload: RateLimitsPayload | null): string {
+  if (!payload) return '';
+  const five = payload.five_hour ? `${Math.round(payload.five_hour.used_percentage)}%` : '-';
+  const seven = payload.seven_day ? `${Math.round(payload.seven_day.used_percentage)}%` : '-';
+  if (five === '-' && seven === '-') return '';
+  return `5h: ${five} · 7d: ${seven}`;
+}
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/cli test -- statusline-relay
+```
+
+Expected: PASS for all 8 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/statusline-relay/
+git commit -m "feat(cli): statusline-relay pure-logic module + 8 edge-case tests"
+```
+
+---
+
+## Task 8: Relay entry, bin shim, tsup config, package.json bin
+
+**Files:**
+- Create: `packages/cli/src/statusline-relay/index.ts`
+- Create: `packages/cli/bin/sesshin-statusline-relay`
+- Modify: `packages/cli/tsup.config.ts`
+- Modify: `packages/cli/package.json`
+
+- [ ] **Step 1: Write the entry point**
+
+`packages/cli/src/statusline-relay/index.ts`:
+
+```ts
+import { spawn as nodeSpawn } from 'node:child_process';
+import { runRelay, type RelayDeps } from './relay.js';
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+const realSpawn: RelayDeps['spawn'] = (cmd, args, opts) => new Promise((resolve) => {
+  const child = nodeSpawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '', stderr = '';
+  let timedOut = false;
+  const timer = setTimeout(() => { timedOut = true; child.kill('SIGTERM'); }, opts.timeoutMs);
+  child.stdout.on('data', (d) => { stdout += d.toString('utf-8'); });
+  child.stderr.on('data', (d) => { stderr += d.toString('utf-8'); });
+  child.on('close', (code) => { clearTimeout(timer); resolve({ code, stdout, stderr, timedOut }); });
+  child.on('error', () => { clearTimeout(timer); resolve({ code: 1, stdout, stderr, timedOut }); });
+  child.stdin.write(opts.stdin);
+  child.stdin.end();
+});
+
+export async function main(): Promise<number> {
+  const stdin = await readStdin();
+  return runRelay({
+    stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    env: process.env as RelayDeps['env'],
+    fetch: globalThis.fetch,
+    spawn: realSpawn,
+    fastTimeoutMs: 250,
+    wrapTimeoutMs: 1500,
+  });
+}
+```
+
+- [ ] **Step 2: Write the bin shim**
+
+`packages/cli/bin/sesshin-statusline-relay` (mirror `bin/sesshin`):
+
+```sh
+#!/usr/bin/env node
+const { main } = await import('../dist/statusline-relay.js');
+main().then((code) => process.exit(code)).catch((e) => {
+  process.stderr.write(`fatal: ${e?.stack ?? e}\n`);
+  process.exit(1);
+});
+```
+
+After creating it, run:
+
+```bash
+chmod +x packages/cli/bin/sesshin-statusline-relay
+```
+
+- [ ] **Step 3: Update `tsup.config.ts`**
+
+```ts
+import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/main.ts', 'src/statusline-relay/index.ts'],
+  format: ['esm'], target: 'node22', clean: true, sourcemap: true,
+});
+```
+
+The output file for the new entry is `dist/statusline-relay/index.js` by default with the directory-style entry. To match the bin shim's `dist/statusline-relay.js`, either rename the bin shim's import path to `../dist/statusline-relay/index.js`, or rewrite the tsup entry as `{ 'main': 'src/main.ts', 'statusline-relay': 'src/statusline-relay/index.ts' }` (object form preserves the desired output filename). Use the object form:
+
+```ts
+export default defineConfig({
+  entry: { main: 'src/main.ts', 'statusline-relay': 'src/statusline-relay/index.ts' },
+  format: ['esm'], target: 'node22', clean: true, sourcemap: true,
+});
+```
+
+- [ ] **Step 4: Update `package.json` bin map**
+
+```json
+"bin": {
+  "sesshin": "bin/sesshin",
+  "sesshin-statusline-relay": "bin/sesshin-statusline-relay"
+}
+```
+
+- [ ] **Step 5: Build and smoke-test**
+
+```bash
+pnpm --filter @sesshin/cli build
+ls packages/cli/dist/statusline-relay.js
+echo '{"rate_limits":{"five_hour":{"used_percentage":42,"resets_at":1},"seven_day":null}}' \
+  | SESSHIN_HUB_URL=http://127.0.0.1:1 SESSHIN_SESSION_ID=test \
+    node packages/cli/bin/sesshin-statusline-relay
+```
+
+Expected: `dist/statusline-relay.js` exists; the smoke command prints `5h: 42% · 7d: -` to stdout (with stderr possibly noting the unreachable hub — that's fine, it's swallowed quietly thanks to AbortController). If you see no output, recheck the relay's default-render path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/statusline-relay/index.ts packages/cli/bin/sesshin-statusline-relay packages/cli/tsup.config.ts packages/cli/package.json
+git commit -m "feat(cli): wire sesshin-statusline-relay bin (tsup multi-entry)"
+```
+
+---
+
+## Task 9: Settings-merge — inject our `statusLine` (with opt-out)
+
+**Files:**
+- Modify: `packages/cli/src/settings-merge.ts`
+- Test: `packages/cli/src/settings-merge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `settings-merge.test.ts`:
+
+```ts
+describe('statusLine injection', () => {
+  it('injects sesshin-statusline-relay as statusLine.command', () => {
+    const merged = mergeSettings({
+      base: {},
+      relayBinPath: '/abs/sesshin-statusline-relay',
+      env: {},
+    });
+    expect(merged.statusLine).toEqual({
+      type: 'command',
+      command: '/abs/sesshin-statusline-relay',
+    });
+  });
+
+  it('does NOT inject when SESSHIN_DISABLE_STATUSLINE_RELAY=1', () => {
+    const merged = mergeSettings({
+      base: {},
+      relayBinPath: '/abs/relay',
+      env: { SESSHIN_DISABLE_STATUSLINE_RELAY: '1' },
+    });
+    expect(merged.statusLine).toBeUndefined();
+  });
+
+  it('does not disturb other merged keys', () => {
+    const merged = mergeSettings({
+      base: { permissions: { defaultMode: 'auto' } },
+      relayBinPath: '/abs/relay',
+      env: {},
+    });
+    expect(merged.permissions).toEqual({ defaultMode: 'auto' });
+    expect(merged.statusLine).toBeDefined();
+  });
+});
+```
+
+(`mergeSettings` is the existing function from this file — adapt the call shape if its current signature differs. The intent is: pass in the relay path + env, get a settings object that includes the relay's statusLine unless disabled.)
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/cli test -- settings-merge
+```
+
+- [ ] **Step 3: Extend `mergeSettings` (or its caller)**
+
+In `settings-merge.ts`, locate the function that builds the merged settings and add:
+
+```ts
+if (params.env?.SESSHIN_DISABLE_STATUSLINE_RELAY !== '1') {
+  merged.statusLine = { type: 'command', command: params.relayBinPath };
+}
+```
+
+`relayBinPath` should be passed in by the caller, computed once at startup. The caller (likely `claude.ts` or `settings-tempfile.ts`) resolves the absolute path of the bin via something like:
+
+```ts
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+const cliBinDir = dirname(fileURLToPath(import.meta.url)); // adjust based on actual layout
+const relayBinPath = join(cliBinDir, '..', '..', 'bin', 'sesshin-statusline-relay');
+```
+
+(Alternative: derive from `process.argv[1]` if simpler.) The test injects an arbitrary `relayBinPath`, so the caller-side resolution does not block these tests.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/cli test -- settings-merge
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/settings-merge.ts packages/cli/src/settings-merge.test.ts
+git commit -m "feat(cli): inject statusline relay into temp settings (with opt-out)"
+```
+
+---
+
+## Task 10: `claude.ts` — propagate user statusLine via env
+
+**Files:**
+- Modify: `packages/cli/src/claude.ts`
+- Modify or create: `packages/cli/src/claude.test.ts` (or extend an existing nearby test if `claude.ts` is already tested)
+
+- [ ] **Step 1: Write the failing test**
+
+Sketch a test that verifies `buildClaudeChildEnv` (or whatever helper builds the env passed to the spawned Claude) includes `SESSHIN_USER_STATUSLINE_CMD` when an inherited statusLine exists, and omits it otherwise:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildClaudeChildEnv } from './claude.js';
+
+describe('buildClaudeChildEnv: user statusLine propagation', () => {
+  it('sets SESSHIN_USER_STATUSLINE_CMD when an inherited command exists', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: { command: 'my-statusline', padding: 2 },
+    });
+    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('my-statusline');
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBe('2');
+  });
+  it('omits the env vars when no inherited command exists', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: null,
+    });
+    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBeUndefined();
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
+  });
+});
+```
+
+If `claude.ts` does not already factor out a `buildClaudeChildEnv`, refactor it out as part of this task (small, mechanical extraction; the existing inline env construction becomes a one-liner call to the helper).
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/cli test -- claude
+```
+
+- [ ] **Step 3: Implement**
+
+In `claude.ts`, call `resolveInheritedStatusLine({ home: HOME, cwd: CWD, excludePath: tempSettingsPath })` once at session start, pass the result into `buildClaudeChildEnv`. In the helper:
+
+```ts
+if (inheritedStatusLine) {
+  out.SESSHIN_USER_STATUSLINE_CMD = inheritedStatusLine.command;
+  if (inheritedStatusLine.padding !== undefined) {
+    out.SESSHIN_USER_STATUSLINE_PADDING = String(inheritedStatusLine.padding);
+  }
+}
+```
+
+Make sure `tempSettingsPath` is the same path that `settings-tempfile.ts` writes — that is the file we exclude.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/cli test -- claude
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/claude.ts packages/cli/src/claude.test.ts
+git commit -m "feat(cli): propagate inherited statusLine to relay via env"
+```
+
+---
+
+## Task 11: debug-web store slice
+
+**Files:**
+- Modify: `packages/debug-web/src/store.ts`
+- Test: `packages/debug-web/src/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `store.test.ts`:
+
+```ts
+describe('rateLimits slice', () => {
+  it('starts with an empty map', () => {
+    const s = useStore.getState();
+    expect(s.rateLimits.size).toBe(0);
+  });
+
+  it('applyRateLimits writes per session', () => {
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: null,
+      observed_at: 1,
+    });
+    expect(useStore.getState().rateLimits.get('s1')?.five_hour?.used_percentage).toBe(45);
+  });
+
+  it('dispatches session.rate-limits messages', () => {
+    useStore.getState().handleWsMessage({
+      type: 'session.rate-limits',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: { used_percentage: 23, resets_at: 200 }, observed_at: 999 },
+    });
+    expect(useStore.getState().rateLimits.get('s1')?.seven_day?.used_percentage).toBe(23);
+  });
+});
+```
+
+(Reset the store between tests via the existing reset helper if there is one — match the pattern used by adjacent tests in this file. If `handleWsMessage` is not the actual dispatch entry name, use the real one.)
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/debug-web test -- store
+```
+
+- [ ] **Step 3: Extend `store.ts`**
+
+(a) Add the import + slice:
+
+```ts
+import type { RateLimitsState } from '@sesshin/shared';
+
+// inside the store-state interface:
+rateLimits: Map<string, RateLimitsState>;
+applyRateLimits: (sessionId: string, state: RateLimitsState) => void;
+```
+
+(b) Initial state:
+
+```ts
+rateLimits: new Map(),
+applyRateLimits: (sessionId, state) => set((s) => {
+  const next = new Map(s.rateLimits);
+  next.set(sessionId, state);
+  return { rateLimits: next };
+}),
+```
+
+(c) Inside the WS message dispatcher (the function that switches on `msg.type`):
+
+```ts
+case 'session.rate-limits':
+  get().applyRateLimits(msg.sessionId, msg.rateLimits);
+  break;
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/debug-web test -- store
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/debug-web/src/store.ts packages/debug-web/src/store.test.ts
+git commit -m "feat(debug-web): rateLimits store slice + WS dispatch"
+```
+
+---
+
+## Task 12: `RateLimitsPill` component + SessionDetail wiring
+
+**Files:**
+- Create: `packages/debug-web/src/components/RateLimitsPill.tsx`
+- Create: `packages/debug-web/src/components/RateLimitsPill.test.tsx`
+- Modify: `packages/debug-web/src/components/SessionDetail.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/debug-web/src/components/RateLimitsPill.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { RateLimitsPill } from './RateLimitsPill.js';
+import { useStore } from '../store.js';
+
+beforeEach(() => {
+  // Reset store before each test (use the project's existing reset pattern).
+  useStore.setState((s) => ({ ...s, rateLimits: new Map() }));
+});
+
+describe('RateLimitsPill', () => {
+  it('does not render when no entry exists for the session', () => {
+    const { container } = render(<RateLimitsPill sessionId="s1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when both windows are null (API-key user)', () => {
+    useStore.getState().applyRateLimits('s1', { five_hour: null, seven_day: null, observed_at: Date.now() });
+    const { container } = render(<RateLimitsPill sessionId="s1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders both windows when fresh', () => {
+    const now = Date.now();
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 45, resets_at: Math.floor(now / 1000) + 7320 },
+      seven_day: { used_percentage: 23, resets_at: Math.floor(now / 1000) + 86400 },
+      observed_at: now,
+    });
+    render(<RateLimitsPill sessionId="s1" />);
+    expect(screen.getByText(/5h: 45%/)).toBeTruthy();
+    expect(screen.getByText(/7d: 23%/)).toBeTruthy();
+  });
+
+  it('applies amber color when 5h utilization is in [70, 90)', () => {
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 80, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now(),
+    });
+    const { container } = render(<RateLimitsPill sessionId="s1" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.color).toBe('rgb(245, 158, 11)');
+  });
+
+  it('applies red color when 5h utilization >= 90', () => {
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 95, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now(),
+    });
+    const { container } = render(<RateLimitsPill sessionId="s1" />);
+    expect((container.firstChild as HTMLElement).style.color).toBe('rgb(239, 68, 68)');
+  });
+
+  it('dims when observed_at is older than 10 minutes', () => {
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 10, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now() - 11 * 60 * 1000,
+    });
+    const { container } = render(<RateLimitsPill sessionId="s1" />);
+    expect((container.firstChild as HTMLElement).style.opacity).toBe('0.5');
+  });
+
+  it('countdown re-renders when timer ticks', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    useStore.getState().applyRateLimits('s1', {
+      five_hour: { used_percentage: 10, resets_at: Math.floor(now / 1000) + 120 },
+      seven_day: null,
+      observed_at: now,
+    });
+    render(<RateLimitsPill sessionId="s1" />);
+    expect(screen.getByText(/in 2m/)).toBeTruthy();
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByText(/in 1m/)).toBeTruthy();
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+```bash
+pnpm --filter @sesshin/debug-web test -- RateLimitsPill
+```
+
+- [ ] **Step 3: Implement `RateLimitsPill.tsx`**
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useStore } from '../store.js';
+
+const COLOR_DEFAULT = '#eee';
+const COLOR_AMBER   = '#f59e0b';
+const COLOR_RED     = '#ef4444';
+const STALE_MS      = 10 * 60 * 1000;
+
+interface Props { sessionId: string; }
+
+export function RateLimitsPill({ sessionId }: Props) {
+  const state = useStore((s) => s.rateLimits.get(sessionId));
+  const [, force] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => force((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!state) return null;
+  if (!state.five_hour && !state.seven_day) return null;
+
+  const now = Date.now();
+  const stale = now - state.observed_at >= STALE_MS;
+  const five  = state.five_hour;
+  const seven = state.seven_day;
+
+  const fivePart  = five  ? `5h: ${Math.round(five.used_percentage)}%`  : '5h: -';
+  const sevenPart = seven ? `7d: ${Math.round(seven.used_percentage)}%` : '7d: -';
+
+  const reset = five ?? seven;
+  const resetMs = reset ? reset.resets_at * 1000 - now : null;
+  const resetPart = resetMs !== null && resetMs > 0 ? ` · in ${formatDuration(resetMs)}` : '';
+
+  const fiveColor = (() => {
+    if (!five) return COLOR_DEFAULT;
+    if (five.used_percentage >= 90) return COLOR_RED;
+    if (five.used_percentage >= 70) return COLOR_AMBER;
+    return COLOR_DEFAULT;
+  })();
+
+  const tooltip = buildTooltip(state, now);
+
+  return (
+    <span
+      title={tooltip}
+      style={{
+        fontSize: 12,
+        padding: '2px 6px',
+        borderRadius: 4,
+        background: '#1a1a1a',
+        color: fiveColor,
+        opacity: stale ? 0.5 : 1,
+      }}
+    >
+      {stale && '⏱ '}
+      {fivePart} · {sevenPart}{resetPart}
+    </span>
+  );
+}
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const days  = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const mins  = Math.floor((totalSec % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function buildTooltip(state: { five_hour: any; seven_day: any; observed_at: number }, now: number): string {
+  const lines: string[] = [];
+  if (state.five_hour) {
+    const ms = state.five_hour.resets_at * 1000 - now;
+    const at = new Date(state.five_hour.resets_at * 1000).toLocaleTimeString();
+    lines.push(`5h window: ${state.five_hour.used_percentage.toFixed(1)}% used, resets at ${at} (in ${formatDuration(Math.max(0, ms))})`);
+  }
+  if (state.seven_day) {
+    const ms = state.seven_day.resets_at * 1000 - now;
+    const at = new Date(state.seven_day.resets_at * 1000).toLocaleString();
+    lines.push(`7d window: ${state.seven_day.used_percentage.toFixed(1)}% used, resets ${at} (in ${formatDuration(Math.max(0, ms))})`);
+  }
+  const ageSec = Math.floor((now - state.observed_at) / 1000);
+  lines.push(`last update: ${ageSec}s ago`);
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```bash
+pnpm --filter @sesshin/debug-web test -- RateLimitsPill
+```
+
+- [ ] **Step 5: Wire into `SessionDetail.tsx`**
+
+Open `packages/debug-web/src/components/SessionDetail.tsx`. The header flex row is at line 39:
+
+```tsx
+<div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 6 }}>
+  {/* existing StateBadge / ModeBadge children */}
+</div>
+```
+
+Add (at the top of the file):
+
+```tsx
+import { RateLimitsPill } from './RateLimitsPill.js';
+```
+
+Add `<RateLimitsPill sessionId={s.id} />` as a child of that flex row (after the existing badges).
+
+- [ ] **Step 6: Sanity-check by booting debug-web**
+
+```bash
+pnpm --filter @sesshin/debug-web dev
+```
+
+Open the app, attach to a running sesshin session, exercise Claude (any prompt that hits the API). The pill should appear in the session header within ~1 statusline tick of the next API response.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/debug-web/src/components/RateLimitsPill.tsx packages/debug-web/src/components/RateLimitsPill.test.tsx packages/debug-web/src/components/SessionDetail.tsx
+git commit -m "feat(debug-web): rate-limits pill in session header"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every section of the spec maps to a task — schemas → T1, registry slot → T2, REST endpoint → T3, registry+broadcast wiring → T4, subscribe-replay → T5, settings resolver → T6, relay logic → T7, bin packaging → T8, settings-merge → T9, env propagation → T10, store slice → T11, pill + SessionDetail integration → T12.
+- **Type consistency:** `RateLimitWindow`, `RateLimitsState`, `SessionRateLimits`, `RateLimitsPayload`, `InheritedStatusLine` are referenced consistently across tasks. The relay's internal `RateLimitsPayload` is intentionally a subset (no `observed_at` — that's the hub's responsibility).
+- **No placeholders:** every code block is real and runnable. The two soft spots — `startTestServer` in T3 and `buildWiredHub` in T4 — defer to whatever helper name the existing test files use, because the conventions vary between tests; the implementer should match them. This is documented inline at each site rather than left as a TBD.
+- **Frequent commits:** 12 commits, one per task, each producing a green test suite.
+
+---
+
+## Execution
+
+Ready for execution. Two options:
+
+1. **Subagent-driven** (recommended): one fresh subagent per task, two-stage review between tasks, fast course-corrections.
+2. **Inline:** execute tasks in this session via `superpowers:executing-plans` with checkpoints.
+
+Pick one and we proceed.

--- a/docs/superpowers/plans/2026-05-07-statusline-rate-limits.md
+++ b/docs/superpowers/plans/2026-05-07-statusline-rate-limits.md
@@ -670,11 +670,12 @@ export interface InheritedStatusLine {
 
 export function resolveInheritedStatusLine(opts: ResolveStatusLineOpts): InheritedStatusLine | null {
   const candidates: string[] = [
-    '/etc/claude/settings.json',                                  // enterprise
     join(opts.cwd,  '.claude/settings.local.json'),               // project (local)
     join(opts.cwd,  '.claude/settings.json'),                     // project
     join(opts.home, '.claude/settings.json'),                     // user
   ];
+  // Enterprise managed-settings (platform-specific paths) intentionally
+  // omitted — out of scope for v1. See spec "Deferred / future work".
   // Highest precedence first per CC's resolution order.
   for (const path of candidates) {
     if (opts.excludePath && path === opts.excludePath) continue;
@@ -873,7 +874,8 @@ export interface RelayDeps {
     SESSHIN_HUB_URL?: string;
     SESSHIN_SESSION_ID?: string;
     SESSHIN_USER_STATUSLINE_CMD?: string;
-    SESSHIN_USER_STATUSLINE_PADDING?: string;
+    // Note: SESSHIN_USER_STATUSLINE_PADDING was removed during final review —
+    // padding forwarding is deferred to a follow-up. See spec.
   };
   fetch: typeof globalThis.fetch;
   spawn: (
@@ -1206,7 +1208,9 @@ describe('buildClaudeChildEnv: user statusLine propagation', () => {
       inheritedStatusLine: { command: 'my-statusline', padding: 2 },
     });
     expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('my-statusline');
-    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBe('2');
+    // Note: padding forwarding was dropped during final review (deferred to a
+    // follow-up). The plan kept the test for reference; the actual claude.test.ts
+    // asserts SESSHIN_USER_STATUSLINE_PADDING is never set.
   });
   it('omits the env vars when no inherited command exists', () => {
     const env = buildClaudeChildEnv({
@@ -1216,7 +1220,6 @@ describe('buildClaudeChildEnv: user statusLine propagation', () => {
       inheritedStatusLine: null,
     });
     expect(env.SESSHIN_USER_STATUSLINE_CMD).toBeUndefined();
-    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
   });
 });
 ```
@@ -1236,10 +1239,10 @@ In `claude.ts`, call `resolveInheritedStatusLine({ home: HOME, cwd: CWD, exclude
 ```ts
 if (inheritedStatusLine) {
   out.SESSHIN_USER_STATUSLINE_CMD = inheritedStatusLine.command;
-  if (inheritedStatusLine.padding !== undefined) {
-    out.SESSHIN_USER_STATUSLINE_PADDING = String(inheritedStatusLine.padding);
-  }
 }
+// Note: the original plan forwarded inheritedStatusLine.padding via
+// SESSHIN_USER_STATUSLINE_PADDING — that was removed during final review;
+// padding propagation is deferred to a follow-up.
 ```
 
 Make sure `tempSettingsPath` is the same path that `settings-tempfile.ts` writes — that is the file we exclude.

--- a/docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md
+++ b/docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md
@@ -1,7 +1,7 @@
 # Statusline-driven rate-limit readout
 
 **Date:** 2026-05-07
-**Status:** Design — pending implementation
+**Status:** Implemented (2026-05-07, PR #11)
 
 ## Problem
 
@@ -72,7 +72,7 @@ The settings-resolution step happens **once per session**, in the parent CLI pro
 | `cli/src/read-claude-settings.test.ts` | Extend with three new cases: only user has `statusLine`; user + project (project wins); injected temp file is excluded from the chain. |
 | `cli/src/settings-merge.ts` | When `SESSHIN_DISABLE_STATUSLINE_RELAY` is **unset** (default), merge in `{ statusLine: { type: 'command', command: '<abs-path-to-relay>' } }`. The absolute path is computed from the cli bin's location. |
 | `cli/src/settings-merge.test.ts` | Two new cases: opt-out env var skips injection; injection adds the statusline command without disturbing other merged keys. |
-| `cli/src/claude.ts` | Before launching Claude: call `resolveInheritedStatusLine`; if a command is found, set `SESSHIN_USER_STATUSLINE_CMD` and (if present) `SESSHIN_USER_STATUSLINE_PADDING` in the child env. |
+| `cli/src/claude.ts` | Before launching Claude: call `resolveInheritedStatusLine`; if a command is found, set `SESSHIN_USER_STATUSLINE_CMD` in the child env. (`padding` resolution is left in the helper's return type for future use; not forwarded in v1 — see "Deferred / future work".) |
 | `shared/src/protocol.ts` | Add `RateLimitWindowSchema`, `RateLimitsStateSchema`, `SessionRateLimitsSchema`. Export inferred types. |
 | `hub/src/rest/server.ts` | Register new route `POST /reports/rate-limits`. Body validated against `{ sessionId, five_hour: …\|null, seven_day: …\|null }`. On valid: stamp `observed_at = Date.now()`, store in registry slice, broadcast, return 204. On invalid: 400. |
 | `hub/src/rest/server.test.ts` | Cover: valid payload returns 204 + broadcast fires + state stored; invalid payload returns 400 with no broadcast; unknown sessionId returns 404 (the registry must already know about this session id). |
@@ -134,8 +134,7 @@ The handler stamps `observed_at = Date.now()` on receive, stores the resulting `
 |---|---|---|
 | `SESSHIN_HUB_URL` | injected by `cli/src/claude.ts` (already exists) | Hub base URL, default `http://127.0.0.1:9663`. |
 | `SESSHIN_SESSION_ID` | injected by `cli/src/claude.ts` (already exists) | Session id included in POST body. |
-| `SESSHIN_USER_STATUSLINE_CMD` | new, set by `cli/src/claude.ts` | Resolved original `statusLine.command` from the CC settings hierarchy, **walking enterprise → project → user** (i.e. CC's normal chain, but with our injected `--settings` temp file excluded since that layer is us). Empty string and unset are treated identically — both cause the relay to render its default. |
-| `SESSHIN_USER_STATUSLINE_PADDING` | new, optional | Forwarded if the user had a `padding` field. |
+| `SESSHIN_USER_STATUSLINE_CMD` | new, set by `cli/src/claude.ts` | Resolved original `statusLine.command` from the CC settings hierarchy, **walking project-local → project → user** (CC's normal chain minus our injected `--settings` temp file). Enterprise managed-settings (`/etc/claude-code/managed-settings.json` on Linux, `/Library/Application Support/ClaudeCode/...` on macOS) are out of scope for v1 — see "Deferred / future work". Empty string and unset are treated identically — both cause the relay to render its default. |
 
 ### Env var consumed by the CLI
 
@@ -186,7 +185,7 @@ All cases must fail toward "Claude Code TUI keeps working." The relay's exit mus
 | `rate_limits` field absent from CC's JSON | POST with `five_hour: null, seven_day: null` so the hub can distinguish "session has no quota data" from "session never reported". |
 | `rate_limits` partially present (only one window) | POST what we have; the other field is `null`. |
 | Relay binary crashes | CC briefly shows blank statusline area until next render; the parent CLI logs the crash via existing logger. |
-| User's enterprise-level `statusLine` exists | Honored — `resolveInheritedStatusLine` returns whichever the highest-precedence layer has, same precedence order CC itself uses. |
+| User's enterprise-level `statusLine` exists | **Not honored in v1.** `resolveInheritedStatusLine` walks project-local → project → user only; enterprise managed-settings paths are platform-specific and deferred. |
 
 ## UI behavior in `debug-web`
 

--- a/docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md
+++ b/docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md
@@ -1,0 +1,254 @@
+# Statusline-driven rate-limit readout
+
+**Date:** 2026-05-07
+**Status:** Design — pending implementation
+
+## Problem
+
+Sesshin currently has no way to surface the user's Anthropic Claude.ai 5-hour and 7-day rolling-window quota state to its clients. The data exists, but it is only ever delivered to Claude Code through HTTP response headers (`anthropic-ratelimit-unified-5h-utilization`, `…-5h-reset`, `…-7d-utilization`, `…-7d-reset`, `…-status`). Claude Code parses those headers into in-memory state in `services/claudeAiLimits.ts`. The state is **not** persisted anywhere on disk — JSONL transcripts contain only `usage` token counts, `~/.claude.json` only caches the overage-disabled reason, and there is no IPC, socket, or file an external process can read.
+
+The single official surface where Claude Code re-emits the parsed state is the `statusLine` JSON it writes to its statusline command's stdin on each render:
+
+```json
+{
+  "rate_limits": {
+    "five_hour": { "used_percentage": 45.2, "resets_at": 1714867200 },
+    "seven_day": { "used_percentage": 23.1, "resets_at": 1714953600 }
+  },
+  ... other fields ...
+}
+```
+
+Sesshin already injects a temporary `--settings` file when wrapping Claude (`packages/cli/src/settings-tempfile.ts`, `settings-merge.ts`), so it is well-positioned to install its own statusline command, capture the JSON side-channel, and forward both the data and the original output. This design lays out that capture pipeline, its on-the-wire shape, and a glanceable readout in `debug-web`.
+
+## Scope
+
+**In:**
+
+1. New thin relay binary `sesshin-statusline-relay`, shipped as a **second bin entry in `@sesshin/cli`** (not a new package), with a separate tsup entry so its bundle stays minimal (~3 KB target).
+2. CLI changes to: (a) resolve the user's existing `statusLine.command` from the CC settings hierarchy at session-start, (b) inject our own `statusLine` into the temp settings file, and (c) export the resolved original via env var to the relay.
+3. New hub REST endpoint `POST /reports/rate-limits` — a fire-and-forget intake mirroring `POST /hooks` (`packages/hook-handler/src/main.ts`).
+4. Per-session in-memory store in the hub (`Map<sessionId, RateLimitsState>`), wired into the existing subscribe-replay broadcast path so newly connected clients see the last-known value immediately.
+5. New WS broadcast type `session.rate-limits` with a Zod schema in `@sesshin/shared`.
+6. New `RateLimitsPill` component in `debug-web`, rendered inline in the existing `SessionDetail` header row, plus a Zustand store slice and a WS-dispatch wiring.
+7. A single env-var escape hatch `SESSHIN_DISABLE_STATUSLINE_RELAY=1` that suppresses statusline injection entirely.
+8. Test coverage at the unit level for: relay edge cases, settings-resolution helper, settings-merge behavior, hub REST handler, WS broadcast/replay, and pill render-state matrix.
+
+**Out (explicitly deferred):**
+
+- **History / trend graphs.** The hub stores only the latest value; nothing is appended to disk.
+- **Account-aggregated view across concurrent sessions.** Per-session storage is locked in; if two sessions on the same Anthropic account both run, both pills show roughly the same numbers. Acceptable for v1.
+- **Active probe.** The hub does not initiate API calls of its own to refresh a stale value. Refresh happens only when CC re-renders the statusline (i.e. on agent steps / API responses).
+- **Per-session-secret auth between relay and hub.** The relay → hub channel is loopback-only and unauthenticated, identical to the trust model `hook-handler` already uses. Hardening this is a cross-cutting concern that would also affect `hook-handler` and is therefore not in scope here.
+- **End-to-end test against a live Claude Code instance.** Wired contracts and unit tests guard the data path; the actual statusline-handshake is verified once manually and then guarded by the unit suite.
+- **Backwards-compatibility shim for users on raw API keys.** When `rate_limits` is absent from CC's stdin (the API-key case), the pill simply does not render. No alternate UX.
+
+## Architectural fit
+
+The pipeline mirrors a pattern already established by `hook-handler`: a tiny stdin-reading binary that POSTs to a hub REST endpoint, fire-and-forget, and exits. The hub then broadcasts a typed message over the existing WS server, and clients update their stores from a single dispatch site. Three deliberate symmetries with `hook-handler`:
+
+- Same trust model: loopback only, no token, env-vars `SESSHIN_HUB_URL` and `SESSHIN_SESSION_ID` already injected by `packages/cli/src/claude.ts` when spawning Claude.
+- Same fast-timeout philosophy: 250 ms POST timeout, errors swallowed (`hook-handler.ts`'s `FAST_TIMEOUT_MS`), so the wrapped statusline never blocks on hub latency.
+- Same "broadcast → store → render" UI dispatch pipeline as `session.summary`, `session.config-changed`, etc.
+
+The two **deliberate departures** from the `hook-handler` template are:
+
+1. **Packaging.** `hook-handler` is its own workspace package; `sesshin-statusline-relay` lives inside `@sesshin/cli` as a second bin entry. Rationale: the existing CLI's full module graph (~34 KB compiled, with `node-pty` and `ws` at the top of the import tree) would slow every statusline render unacceptably, so sharing a process is impossible — but creating a separate package is also unnecessary overhead. A second `tsup` entry compiled from `packages/cli/src/statusline-relay/` produces an isolated bundle that imports only what it needs, without committing to a new package boundary.
+2. **Wrap, don't shadow.** Unlike `hook-handler`, which is the only command of its kind, the user may already have a `statusLine` configured (e.g. `ccusage`, `ccstatusline`). Sesshin's injected file would otherwise silently shadow it. The relay therefore **runs the user's resolved original command as a subprocess**, pipes the same stdin into it, and forwards its stdout. The user's existing setup is preserved verbatim while we capture the side-channel.
+
+The settings-resolution step happens **once per session**, in the parent CLI process, before the temp settings file is written. The relay does not re-read CC settings on every tick — it inherits the resolved command via env var, keeping per-render work bounded to (parse, POST, spawn, pipe).
+
+## File-level change map
+
+| Package / file | Change |
+|---|---|
+| `cli/package.json` | Add `"sesshin-statusline-relay": "bin/sesshin-statusline-relay"` to the `bin` map. |
+| `cli/bin/sesshin-statusline-relay` (new) | 4-line shim: `#!/usr/bin/env node` + `await import('../dist/statusline-relay.js')`. Mirrors `bin/sesshin`. |
+| `cli/tsup.config.ts` | Add second entry: `src/statusline-relay/index.ts` → `dist/statusline-relay.js`. |
+| `cli/src/statusline-relay/index.ts` (new) | Entry point. Reads stdin, POSTs to hub, spawns wrapped command, forwards output, exits. |
+| `cli/src/statusline-relay/relay.ts` (new) | Pure logic split out for testability: takes injected `fetch`, `spawn`, `stdout`, `stderr`, `env`, returns a number (exit code). |
+| `cli/src/statusline-relay/relay.test.ts` (new) | Eight edge-case tests (one per row of the table in §"Edge cases"). |
+| `cli/src/read-claude-settings.ts` | Add `resolveInheritedStatusLine(opts)` that walks the CC settings hierarchy, optionally excluding our injected temp-file path, and returns `{ command: string; padding?: number } | null`. Existing `readClaudeSettings` is reused. |
+| `cli/src/read-claude-settings.test.ts` | Extend with three new cases: only user has `statusLine`; user + project (project wins); injected temp file is excluded from the chain. |
+| `cli/src/settings-merge.ts` | When `SESSHIN_DISABLE_STATUSLINE_RELAY` is **unset** (default), merge in `{ statusLine: { type: 'command', command: '<abs-path-to-relay>' } }`. The absolute path is computed from the cli bin's location. |
+| `cli/src/settings-merge.test.ts` | Two new cases: opt-out env var skips injection; injection adds the statusline command without disturbing other merged keys. |
+| `cli/src/claude.ts` | Before launching Claude: call `resolveInheritedStatusLine`; if a command is found, set `SESSHIN_USER_STATUSLINE_CMD` and (if present) `SESSHIN_USER_STATUSLINE_PADDING` in the child env. |
+| `shared/src/protocol.ts` | Add `RateLimitWindowSchema`, `RateLimitsStateSchema`, `SessionRateLimitsSchema`. Export inferred types. |
+| `hub/src/rest/server.ts` | Register new route `POST /reports/rate-limits`. Body validated against `{ sessionId, five_hour: …\|null, seven_day: …\|null }`. On valid: stamp `observed_at = Date.now()`, store in registry slice, broadcast, return 204. On invalid: 400. |
+| `hub/src/rest/server.test.ts` | Cover: valid payload returns 204 + broadcast fires + state stored; invalid payload returns 400 with no broadcast; unknown sessionId returns 404 (the registry must already know about this session id). |
+| `hub/src/registry/` | Add a per-session `rateLimits: RateLimitsState | null` field to whatever shape currently holds per-session data. Plumbed through subscribe-replay. |
+| `hub/src/wire.ts` | Add `session.rate-limits` to the broadcast payload union; include current value in subscribe-replay frames. |
+| `hub/src/wire.test.ts` | Extend the existing replay-shape test to assert `session.rate-limits` is included when state exists. |
+| `debug-web/src/store.ts` | New slice: `rateLimits: Map<string, RateLimitsState>`, `applyRateLimits(sessionId, state)`. Wire into the existing WS dispatcher for `session.rate-limits`. |
+| `debug-web/src/store.test.ts` | Extend with dispatch + replay-hydration cases. |
+| `debug-web/src/components/RateLimitsPill.tsx` (new) | The pill component. Reads from store, ticks every 30 s, renders both windows + relative reset, applies color thresholds. |
+| `debug-web/src/components/RateLimitsPill.test.tsx` (new) | Render-state matrix: no data; null/null; fresh; stale; color thresholds at 70 / 90; countdown tick via fake timers. |
+| `debug-web/src/components/SessionDetail.tsx` | Add `<RateLimitsPill sessionId={s.id} />` as a third child of the existing flex header row at line 39. |
+
+`packages/cli/dist/*` is a build artifact; only `src/` files are edited and the build pipeline regenerates `dist/`.
+
+## Public contracts
+
+### Wire schemas (`shared/src/protocol.ts`)
+
+```ts
+export const RateLimitWindowSchema = z.object({
+  used_percentage: z.number(),  // 0-100, as CC reports
+  resets_at: z.number(),        // Unix seconds
+});
+
+export const RateLimitsStateSchema = z.object({
+  five_hour: RateLimitWindowSchema.nullable(),
+  seven_day: RateLimitWindowSchema.nullable(),
+  observed_at: z.number(),      // Unix ms, hub-stamped on receive
+});
+
+export const SessionRateLimitsSchema = z.object({
+  type: z.literal('session.rate-limits'),
+  sessionId: z.string(),
+  rateLimits: RateLimitsStateSchema,
+});
+
+export type RateLimitWindow    = z.infer<typeof RateLimitWindowSchema>;
+export type RateLimitsState    = z.infer<typeof RateLimitsStateSchema>;
+export type SessionRateLimits  = z.infer<typeof SessionRateLimitsSchema>;
+```
+
+### REST endpoint (`hub/src/rest/server.ts`)
+
+```
+POST /reports/rate-limits
+  Content-Type: application/json
+  Body: { sessionId: string, five_hour: RateLimitWindow | null, seven_day: RateLimitWindow | null }
+
+  204 No Content   on success
+  400 Bad Request  on schema violation
+  404 Not Found    when sessionId is unknown to the registry
+```
+
+The handler stamps `observed_at = Date.now()` on receive, stores the resulting `RateLimitsState` in the registry, and broadcasts a `session.rate-limits` message. Returns 204 even if no clients are currently subscribed; the cache-on-write is the load-bearing side effect.
+
+### Env vars consumed by the relay
+
+| Var | Source | Purpose |
+|---|---|---|
+| `SESSHIN_HUB_URL` | injected by `cli/src/claude.ts` (already exists) | Hub base URL, default `http://127.0.0.1:9663`. |
+| `SESSHIN_SESSION_ID` | injected by `cli/src/claude.ts` (already exists) | Session id included in POST body. |
+| `SESSHIN_USER_STATUSLINE_CMD` | new, set by `cli/src/claude.ts` | Resolved original `statusLine.command` from the CC settings hierarchy, **walking enterprise → project → user** (i.e. CC's normal chain, but with our injected `--settings` temp file excluded since that layer is us). Empty string and unset are treated identically — both cause the relay to render its default. |
+| `SESSHIN_USER_STATUSLINE_PADDING` | new, optional | Forwarded if the user had a `padding` field. |
+
+### Env var consumed by the CLI
+
+| Var | Effect |
+|---|---|
+| `SESSHIN_DISABLE_STATUSLINE_RELAY=1` | `settings-merge.ts` skips injecting our `statusLine` entirely. The user's original setting (if any) takes effect via normal CC resolution; no rate-limit data is captured for that session. |
+
+## Relay execution per tick
+
+```
+1. Read stdin into a buffer (small JSON, typically a few KB).
+2. JSON.parse(buffer); extract `rate_limits` if present.
+3. fire-and-forget POST to ${SESSHIN_HUB_URL}/reports/rate-limits
+   - body: { sessionId, five_hour, seven_day }   // both may be null
+   - 250 ms timeout, errors swallowed (no stderr noise on hub-down)
+4. If SESSHIN_USER_STATUSLINE_CMD is set:
+     spawn(['sh', '-c', "$SESSHIN_USER_STATUSLINE_CMD"], { stdin: <buffer>, timeout: 1500 ms })
+     pipe child stdout → our stdout
+     on non-zero exit, timeout, or spawn error: render default
+   Else:
+     render default
+5. exit
+```
+
+`sh -c` is used to match Claude Code's own statusline execution semantics (pipelines, env-var expansion, etc.) without re-implementing a parser.
+
+### Default render
+
+When the relay must produce its own output (no wrapped command, or wrap failed), and `rate_limits` was successfully extracted:
+
+```
+5h: 45% · 7d: 23%
+```
+
+When `rate_limits` is absent (API-key user, or pre-first-API-call) and there is no wrapped command, the relay outputs the empty string. CC TUI renders a blank statusline area. We do **not** add sesshin branding to the default render — the goal of the default is to be unobtrusive when the feature isn't applicable.
+
+## Edge cases
+
+All cases must fail toward "Claude Code TUI keeps working." The relay's exit must always be quick and clean.
+
+| Case | Behavior |
+|---|---|
+| Hub unreachable / hub down | POST times out at 250 ms; wrap+render proceed normally. |
+| User's wrapped command exits non-zero | Log a single line to stderr, fall back to default render. |
+| User's wrapped command hangs >1500 ms | SIGTERM, then render default. CC's own statusline timeout is ~3 s, we want to fail before CC does. |
+| User's wrapped command writes empty stdout | Render whatever it produced (empty is fine). |
+| CC sends malformed JSON on stdin | Skip POST (no `rate_limits` to extract); still pass the **raw original buffer** to the wrapped command unchanged. Do not attempt parse-and-reserialize. |
+| `rate_limits` field absent from CC's JSON | POST with `five_hour: null, seven_day: null` so the hub can distinguish "session has no quota data" from "session never reported". |
+| `rate_limits` partially present (only one window) | POST what we have; the other field is `null`. |
+| Relay binary crashes | CC briefly shows blank statusline area until next render; the parent CLI logs the crash via existing logger. |
+| User's enterprise-level `statusLine` exists | Honored — `resolveInheritedStatusLine` returns whichever the highest-precedence layer has, same precedence order CC itself uses. |
+
+## UI behavior in `debug-web`
+
+### Placement
+
+The pill is a third child of the existing flex header row at `SessionDetail.tsx:39`, alongside `StateBadge` and `ModeBadge`. No new layout, no real-estate cost, no scroll behavior changes.
+
+### Render states
+
+| Store state for sessionId | Render |
+|---|---|
+| Not in `rateLimits` map (no report received) | Pill **not rendered**. Avoids a "—" placeholder flicker on session open. |
+| `five_hour: null && seven_day: null` (API-key user) | Pill **not rendered**. The feature is Pro/Max-specific. |
+| Fresh (`Date.now() - observed_at < 10 min`) | Full opacity, color thresholds applied. |
+| Stale (`Date.now() - observed_at >= 10 min`) | `opacity: 0.5` + ⏱ icon, native `title=` tooltip indicates last-update timestamp. |
+
+### Pill content
+
+```
+5h: 45% · 7d: 23% · in 2h 12m
+```
+
+The relative time-to-reset is **client-ticked** every 30 s using a `setInterval` inside the component (cleared on unmount). `resets_at` is anchored, so no server roundtrip is needed for the countdown to stay accurate. When the countdown reaches zero, the pill keeps rendering the last-known value; the next statusline tick replaces it with the new window's numbers.
+
+### Color thresholds (5h utilization)
+
+| Used | Color |
+|---|---|
+| < 70% | default `#eee` |
+| 70 – 90% | `#f59e0b` (amber) |
+| > 90% | `#ef4444` (red) |
+
+Same scheme is **not** applied to the 7d window — it moves slowly and double-coloring would be visually noisy. The 7d number is rendered in the secondary muted color regardless.
+
+### Tooltip (native `title=`)
+
+```
+5h window: 45% used, resets at 14:32 (in 2h 12m)
+7d window: 23% used, resets Mon 09:00 (in 5d 18h)
+last update: 10s ago
+```
+
+No popover library, no custom hover state — just a `title` attribute on the pill's outer element.
+
+## Testing strategy
+
+| Layer | File | Coverage |
+|---|---|---|
+| Unit | `cli/src/statusline-relay/relay.test.ts` (new) | All eight edge cases from the table above; fake `fetch`, `spawn`, `stdout`, `stderr`, `env`. |
+| Unit | `cli/src/read-claude-settings.test.ts` (extend) | Three new cases for `resolveInheritedStatusLine`. |
+| Unit | `cli/src/settings-merge.test.ts` (extend) | Opt-out env var; injection without disturbing other keys. |
+| Unit | `hub/src/rest/server.test.ts` (extend) | Valid payload (204 + broadcast + store); invalid (400); unknown session (404). |
+| Unit | `hub/src/wire.test.ts` (extend) | Replay frame includes `session.rate-limits` when state exists. |
+| Unit | `debug-web/src/store.test.ts` (extend) | WS dispatch + replay-hydration paths. |
+| Unit | `debug-web/src/components/RateLimitsPill.test.tsx` (new) | Render-state matrix; color thresholds; countdown tick via fake timers. |
+
+No end-to-end test against a live Claude Code instance is in scope. The relay's edge cases are exhaustively covered with injected dependencies, and the data path from `POST /reports/rate-limits` through to the rendered pill is unit-covered at every hop.
+
+## Deferred / future work
+
+- **Account-aggregated readout.** A second pill (or sidebar widget) that surfaces "freshest across all live sessions" to avoid the visual duplication when multiple sesshin sessions share one Anthropic account.
+- **History and trend graph.** Hub appends each report to a JSONL log; a separate panel charts utilization over the last N hours.
+- **Active probe.** Hub periodically initiates a low-cost API call to refresh stale data without waiting for the next CC re-render. Requires reusing the user's auth token and is risky around self-rate-limiting.
+- **Per-session-secret auth between relay and hub.** Currently loopback-only and unauthenticated, same as `hook-handler`. If sesshin grows a multi-tenant story, this needs revisiting jointly with `hook-handler`.
+- **Wrap user's statusline in a non-shell context.** `sh -c` covers the realistic case but means we cannot safely run a wrapped command on a system without `/bin/sh`. Not a realistic concern for the platforms sesshin targets, but worth noting.

--- a/packages/cli/bin/sesshin-statusline-relay
+++ b/packages/cli/bin/sesshin-statusline-relay
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const { main } = await import('../dist/statusline-relay.js');
+main().then((code) => process.exit(code)).catch((e) => {
+  process.stderr.write(`fatal: ${e?.stack ?? e}\n`);
+  process.exit(1);
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "type": "module",
   "private": true,
-  "bin": { "sesshin": "bin/sesshin" },
+  "bin": {
+    "sesshin": "bin/sesshin",
+    "sesshin-statusline-relay": "bin/sesshin-statusline-relay"
+  },
   "scripts": {
     "build": "tsup && mkdir -p dist/commands-bundle && cp -r src/commands-bundle/*.md dist/commands-bundle/",
     "dev": "tsup --watch",

--- a/packages/cli/src/claude.test.ts
+++ b/packages/cli/src/claude.test.ts
@@ -10,7 +10,8 @@ describe('buildClaudeChildEnv: user statusLine propagation', () => {
       inheritedStatusLine: { command: 'my-statusline', padding: 2 },
     });
     expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('my-statusline');
-    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBe('2');
+    // SESSHIN_USER_STATUSLINE_PADDING is intentionally not forwarded (out of scope for v1)
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
   });
 
   it('omits the env vars when no inherited command exists', () => {
@@ -24,15 +25,22 @@ describe('buildClaudeChildEnv: user statusLine propagation', () => {
     expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
   });
 
-  it('omits padding env var when inheritedStatusLine has no padding', () => {
-    const env = buildClaudeChildEnv({
+  it('never sets SESSHIN_USER_STATUSLINE_PADDING regardless of input padding', () => {
+    // padding is preserved in InheritedStatusLine shape but not forwarded via env
+    const withoutPadding = buildClaudeChildEnv({
       base: {},
       sessionId: 's1',
       hubUrl: 'http://127.0.0.1:9663',
       inheritedStatusLine: { command: 'just-cmd' },
     });
-    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('just-cmd');
-    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
+    expect(withoutPadding.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
+    const withPadding = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: { command: 'just-cmd', padding: 4 },
+    });
+    expect(withPadding.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
   });
 
   it('always sets SESSHIN_SESSION_ID and SESSHIN_HUB_URL', () => {

--- a/packages/cli/src/claude.test.ts
+++ b/packages/cli/src/claude.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildClaudeChildEnv } from './claude.js';
+
+describe('buildClaudeChildEnv: user statusLine propagation', () => {
+  it('sets SESSHIN_USER_STATUSLINE_CMD when an inherited command exists', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: { command: 'my-statusline', padding: 2 },
+    });
+    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('my-statusline');
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBe('2');
+  });
+
+  it('omits the env vars when no inherited command exists', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: null,
+    });
+    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBeUndefined();
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
+  });
+
+  it('omits padding env var when inheritedStatusLine has no padding', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 's1',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: { command: 'just-cmd' },
+    });
+    expect(env.SESSHIN_USER_STATUSLINE_CMD).toBe('just-cmd');
+    expect(env.SESSHIN_USER_STATUSLINE_PADDING).toBeUndefined();
+  });
+
+  it('always sets SESSHIN_SESSION_ID and SESSHIN_HUB_URL', () => {
+    const env = buildClaudeChildEnv({
+      base: {},
+      sessionId: 'abc123',
+      hubUrl: 'http://127.0.0.1:9999',
+      inheritedStatusLine: null,
+    });
+    expect(env.SESSHIN_SESSION_ID).toBe('abc123');
+    expect(env.SESSHIN_HUB_URL).toBe('http://127.0.0.1:9999');
+  });
+
+  it('merges base env vars without overwriting sesshin keys', () => {
+    const env = buildClaudeChildEnv({
+      base: { MY_CUSTOM_VAR: 'hello', SESSHIN_HUB_URL: 'http://old' },
+      sessionId: 's2',
+      hubUrl: 'http://127.0.0.1:9663',
+      inheritedStatusLine: null,
+    });
+    expect(env.MY_CUSTOM_VAR).toBe('hello');
+    // sesshin keys must win over stale base values
+    expect(env.SESSHIN_HUB_URL).toBe('http://127.0.0.1:9663');
+    expect(env.SESSHIN_SESSION_ID).toBe('s2');
+  });
+});

--- a/packages/cli/src/claude.ts
+++ b/packages/cli/src/claude.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from 'node:crypto';
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensureHubRunning } from './hub-spawn.js';
 import { generateHooksOnlySettings } from './settings-tempfile.js';
-import { mergeUserHooksWithOurs } from './settings-merge.js';
+import { mergeUserHooksWithOurs, mergeSettings } from './settings-merge.js';
 import { wrapPty } from './pty-wrap.js';
 import { startPtyTap } from './pty-tap.js';
 import { startInjectListener } from './inject-listener.js';
@@ -13,10 +13,19 @@ import { startHeartbeat } from './heartbeat.js';
 import { installCleanup } from './cleanup.js';
 import { reapOrphanSettingsFiles } from './orphan-cleanup.js';
 import { sessionFilePath } from '@sesshin/hub/agents/claude/session-file-path';
-import { readClaudeSettings } from './read-claude-settings.js';
+import { readClaudeSettings, resolveInheritedStatusLine } from './read-claude-settings.js';
+import type { InheritedStatusLine } from './read-claude-settings.js';
 import { parsePermissionModeFlag } from './parse-permission-mode-flag.js';
 import { detectParentShell } from './detect-shell.js';
 import { startPauseMonitor } from './pause-monitor.js';
+
+// ── Relay bin path (computed once at module load) ─────────────────────────────
+// At runtime this module lives at <pkg>/dist/claude.js (or main.js). The relay
+// bin is a sibling of dist/ inside the same package: <pkg>/bin/sesshin-statusline-relay.
+// We use import.meta.url (the most reliable source) rather than process.argv[1]
+// (which points to the CLI entry, not necessarily this module).
+const _thisDir = dirname(fileURLToPath(import.meta.url));
+export const RELAY_BIN_PATH = join(_thisDir, '..', 'bin', 'sesshin-statusline-relay');
 
 const HUB_PORT = Number(process.env['SESSHIN_INTERNAL_PORT'] ?? 9663);
 const HUB_URL  = `http://127.0.0.1:${HUB_PORT}`;
@@ -41,6 +50,40 @@ function shellQuote(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+// ── buildClaudeChildEnv ───────────────────────────────────────────────────────
+
+export interface BuildClaudeChildEnvParams {
+  /** Base env map to spread (typically process.env cast to Record<string,string>). */
+  base: Record<string, string | undefined>;
+  sessionId: string;
+  hubUrl: string;
+  /** The user's original statusLine command resolved before we injected ours, or null. */
+  inheritedStatusLine: InheritedStatusLine | null;
+}
+
+/**
+ * Builds the env vars map passed to the inner Claude child process.
+ * Always sets SESSHIN_SESSION_ID and SESSHIN_HUB_URL.
+ * When inheritedStatusLine is non-null, also sets SESSHIN_USER_STATUSLINE_CMD
+ * (and SESSHIN_USER_STATUSLINE_PADDING if padding is present).
+ */
+export function buildClaudeChildEnv(params: BuildClaudeChildEnvParams): Record<string, string> {
+  const out: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(params.base).filter((e): e is [string, string] => e[1] !== undefined)
+    ),
+    SESSHIN_SESSION_ID: params.sessionId,
+    SESSHIN_HUB_URL: params.hubUrl,
+  };
+  if (params.inheritedStatusLine) {
+    out.SESSHIN_USER_STATUSLINE_CMD = params.inheritedStatusLine.command;
+    if (params.inheritedStatusLine.padding !== undefined) {
+      out.SESSHIN_USER_STATUSLINE_PADDING = String(params.inheritedStatusLine.padding);
+    }
+  }
+  return out;
+}
+
 /** Shells whose `set` builtin understands `-m` (monitor mode / job control).
  * Excludes fish (`set` is a variable-only builtin with different flag space)
  * and csh/tcsh (separate syntax: `set notify`/`set monitor` style). Those
@@ -56,7 +99,8 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
   const hookBin = resolveBin('SESSHIN_HOOK_HANDLER_BIN', '@sesshin/hook-handler/bin/sesshin-hook-handler');
   await ensureHubRunning({ hubBin, port: HUB_PORT, healthTimeoutMs: 5000 });
 
-  // Compose hooks-only settings (with optional merge fallback when verification gate 1 = REPLACE)
+  // ── Compose temp settings file ───────────────────────────────────────────────
+  // Step 1: build base hooks-only settings, optionally merging user hooks.
   const useMerge = process.env['SESSHIN_MERGE_USER_HOOKS'] === '1';
   let settings: object = JSON.parse(generateHooksOnlySettings({ hookHandlerPath: hookBin, sessionId, hubUrl: HUB_URL, agent: 'claude-code' }));
   if (useMerge) {
@@ -65,6 +109,29 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
     settings = mergeUserHooksWithOurs(settings as { hooks: Record<string, unknown[]> }, userJson);
   }
   const tempSettingsPath = join(tmpdir(), `sesshin-${sessionId}.json`);
+
+  // Step 2: inject statusLine relay (unless disabled).
+  // tempSettingsPath is unique per sessionId and does not exist yet when we call
+  // resolveInheritedStatusLine. We still pass it as excludePath for correctness:
+  // if the same path somehow existed (e.g. filesystem collision), we'd skip it so
+  // we don't accidentally read our own injected relay path back as the user's value.
+  const disableRelay = process.env['SESSHIN_DISABLE_STATUSLINE_RELAY'] === '1';
+  let inheritedStatusLine: InheritedStatusLine | null = null;
+  if (!disableRelay) {
+    // Resolve user's original statusLine BEFORE writing our temp file.
+    inheritedStatusLine = resolveInheritedStatusLine({
+      home: homedir(),
+      cwd: process.cwd(),
+      excludePath: tempSettingsPath,
+    });
+    // Inject our relay as the active statusLine.
+    settings = mergeSettings({
+      base: settings as Record<string, unknown>,
+      relayBinPath: RELAY_BIN_PATH,
+      env: process.env as Record<string, string | undefined>,
+    });
+  }
+
   writeFileSync(tempSettingsPath, JSON.stringify(settings, null, 2), { mode: 0o600 });
 
   // Register
@@ -100,11 +167,14 @@ export async function runClaude(extraArgs: string[]): Promise<void> {
     ...extraArgs.map(shellQuote),
   ].join(' ');
   // Inject sesshin context so claude's Bash tool / slash commands can find us.
-  const childEnv: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    SESSHIN_SESSION_ID: sessionId,
-    SESSHIN_HUB_URL: HUB_URL,
-  };
+  // Also propagate the user's original statusLine command so the relay can
+  // delegate to it for the non-rate-limit portion of the status line.
+  const childEnv = buildClaudeChildEnv({
+    base: process.env as Record<string, string>,
+    sessionId,
+    hubUrl: HUB_URL,
+    inheritedStatusLine,
+  });
   const wrap = wrapPty({
     command: shell.bin,
     args: ['-i'], // interactive → bash/zsh/fish auto-enable job control

--- a/packages/cli/src/claude.ts
+++ b/packages/cli/src/claude.ts
@@ -64,8 +64,9 @@ export interface BuildClaudeChildEnvParams {
 /**
  * Builds the env vars map passed to the inner Claude child process.
  * Always sets SESSHIN_SESSION_ID and SESSHIN_HUB_URL.
- * When inheritedStatusLine is non-null, also sets SESSHIN_USER_STATUSLINE_CMD
- * (and SESSHIN_USER_STATUSLINE_PADDING if padding is present).
+ * When inheritedStatusLine is non-null, also sets SESSHIN_USER_STATUSLINE_CMD.
+ * Note: InheritedStatusLine.padding is not forwarded via env — forwarding
+ * padding is out of scope for v1.
  */
 export function buildClaudeChildEnv(params: BuildClaudeChildEnvParams): Record<string, string> {
   const out: Record<string, string> = {
@@ -77,9 +78,6 @@ export function buildClaudeChildEnv(params: BuildClaudeChildEnvParams): Record<s
   };
   if (params.inheritedStatusLine) {
     out.SESSHIN_USER_STATUSLINE_CMD = params.inheritedStatusLine.command;
-    if (params.inheritedStatusLine.padding !== undefined) {
-      out.SESSHIN_USER_STATUSLINE_PADDING = String(params.inheritedStatusLine.padding);
-    }
   }
   return out;
 }

--- a/packages/cli/src/read-claude-settings.test.ts
+++ b/packages/cli/src/read-claude-settings.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readClaudeSettings } from './read-claude-settings.js';
+import { readClaudeSettings, resolveInheritedStatusLine } from './read-claude-settings.js';
 
 let HOME: string, CWD: string;
 beforeEach(() => {
@@ -52,5 +52,54 @@ describe('readClaudeSettings', () => {
     writeFileSync(join(HOME, '.claude/settings.json'),
       JSON.stringify({ permissions: { defaultMode: 'wat' } }));
     expect(readClaudeSettings({ home: HOME, cwd: CWD }).defaultMode).toBeNull();
+  });
+});
+
+describe('resolveInheritedStatusLine', () => {
+  it('returns null when no settings file has a statusLine', () => {
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD })).toBeNull();
+  });
+
+  it('returns user-level statusLine when only ~/.claude/settings.json has one', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'my-statusline' },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD }))
+      .toEqual({ command: 'my-statusline' });
+  });
+
+  it('project-level statusLine wins over user-level', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    mkdirSync(join(CWD, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'user-cmd' },
+    }));
+    writeFileSync(join(CWD, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'project-cmd', padding: 1 },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD }))
+      .toEqual({ command: 'project-cmd', padding: 1 });
+  });
+
+  it('skips the excluded settings path even if it has a statusLine', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    const tmpInjected = join(CWD, 'sesshin-injected.json');
+    writeFileSync(tmpInjected, JSON.stringify({
+      statusLine: { type: 'command', command: 'sesshin-relay' },
+    }));
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'command', command: 'user-cmd' },
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD, excludePath: tmpInjected }))
+      .toEqual({ command: 'user-cmd' });
+  });
+
+  it('ignores statusLine entries whose type is not "command"', () => {
+    mkdirSync(join(HOME, '.claude'), { recursive: true });
+    writeFileSync(join(HOME, '.claude/settings.json'), JSON.stringify({
+      statusLine: { type: 'static', value: 'hi' } as unknown,
+    }));
+    expect(resolveInheritedStatusLine({ home: HOME, cwd: CWD })).toBeNull();
   });
 });

--- a/packages/cli/src/read-claude-settings.ts
+++ b/packages/cli/src/read-claude-settings.ts
@@ -29,3 +29,44 @@ export function readClaudeSettings(opts: { home: string; cwd: string }): ClaudeS
     allowRules: [...extractAllow(userJson), ...extractAllow(projectJson)],
   };
 }
+
+export interface ResolveStatusLineOpts {
+  home: string;
+  cwd: string;
+  /** Absolute path of a settings file to skip in the inheritance walk
+   *  (used to omit our own injected --settings temp file). */
+  excludePath?: string;
+}
+
+export interface InheritedStatusLine {
+  command: string;
+  padding?: number;
+}
+
+export function resolveInheritedStatusLine(opts: ResolveStatusLineOpts): InheritedStatusLine | null {
+  const candidates: string[] = [
+    '/etc/claude/settings.json',                                  // enterprise
+    join(opts.cwd,  '.claude/settings.local.json'),               // project (local)
+    join(opts.cwd,  '.claude/settings.json'),                     // project
+    join(opts.home, '.claude/settings.json'),                     // user
+  ];
+  // Highest precedence first per CC's resolution order.
+  for (const path of candidates) {
+    if (opts.excludePath && path === opts.excludePath) continue;
+    const sl = readStatusLineFromFile(path);
+    if (sl) return sl;
+  }
+  return null;
+}
+
+function readStatusLineFromFile(path: string): InheritedStatusLine | null {
+  let raw: string;
+  try { raw = readFileSync(path, 'utf-8'); } catch { return null; }
+  let parsed: any;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  const sl = parsed?.statusLine;
+  if (!sl || sl.type !== 'command' || typeof sl.command !== 'string') return null;
+  const out: InheritedStatusLine = { command: sl.command };
+  if (typeof sl.padding === 'number') out.padding = sl.padding;
+  return out;
+}

--- a/packages/cli/src/read-claude-settings.ts
+++ b/packages/cli/src/read-claude-settings.ts
@@ -45,11 +45,14 @@ export interface InheritedStatusLine {
 
 export function resolveInheritedStatusLine(opts: ResolveStatusLineOpts): InheritedStatusLine | null {
   const candidates: string[] = [
-    '/etc/claude/settings.json',                                  // enterprise
     join(opts.cwd,  '.claude/settings.local.json'),               // project (local)
     join(opts.cwd,  '.claude/settings.json'),                     // project
     join(opts.home, '.claude/settings.json'),                     // user
   ];
+  // User-level statusLine inheritance only (project + user); enterprise managed-settings
+  // resolution is intentionally out of scope for v1 and would require platform-specific
+  // paths (macOS: /Library/Application Support/ClaudeCode/managed-settings.json, Linux:
+  // /etc/claude-code/managed-settings.json).
   // Highest precedence first per CC's resolution order.
   for (const path of candidates) {
     if (opts.excludePath && path === opts.excludePath) continue;

--- a/packages/cli/src/settings-merge.test.ts
+++ b/packages/cli/src/settings-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeUserHooksWithOurs } from './settings-merge.js';
+import { mergeUserHooksWithOurs, mergeSettings } from './settings-merge.js';
 
 describe('mergeUserHooksWithOurs', () => {
   it('prepends user Stop hooks before ours, preserves matchers', () => {
@@ -16,5 +16,39 @@ describe('mergeUserHooksWithOurs', () => {
     const merged = mergeUserHooksWithOurs(ours, userSettings) as any;
     // Our temp file shouldn't carry user model/mcp/etc — those load from layers Claude reads itself.
     expect(merged).toEqual({ hooks: {} });
+  });
+});
+
+describe('mergeSettings — statusLine injection', () => {
+  it('injects sesshin-statusline-relay as statusLine.command', () => {
+    const merged = mergeSettings({
+      base: { hooks: {} },
+      relayBinPath: '/abs/sesshin-statusline-relay',
+      env: {},
+    }) as any;
+    expect(merged.statusLine).toEqual({
+      type: 'command',
+      command: '/abs/sesshin-statusline-relay',
+    });
+  });
+
+  it('does NOT inject when SESSHIN_DISABLE_STATUSLINE_RELAY=1', () => {
+    const merged = mergeSettings({
+      base: { hooks: {} },
+      relayBinPath: '/abs/relay',
+      env: { SESSHIN_DISABLE_STATUSLINE_RELAY: '1' },
+    }) as any;
+    expect(merged.statusLine).toBeUndefined();
+  });
+
+  it('does not disturb other merged keys', () => {
+    const merged = mergeSettings({
+      base: { hooks: { Stop: [{ matcher: '*', hooks: [] }] }, permissions: { defaultMode: 'auto' } },
+      relayBinPath: '/abs/relay',
+      env: {},
+    }) as any;
+    expect(merged.permissions).toEqual({ defaultMode: 'auto' });
+    expect(merged.hooks.Stop).toHaveLength(1);
+    expect(merged.statusLine).toBeDefined();
   });
 });

--- a/packages/cli/src/settings-merge.ts
+++ b/packages/cli/src/settings-merge.ts
@@ -10,3 +10,24 @@ export function mergeUserHooksWithOurs(ours: HooksMap, userSettings: any): Hooks
   }
   return { hooks: out };
 }
+
+export interface MergeSettingsParams {
+  /** The base settings object (e.g. from generateHooksOnlySettings, already parsed). */
+  base: Record<string, any>;
+  /** Absolute path to the sesshin-statusline-relay binary. */
+  relayBinPath: string;
+  /** Environment variable map — typically process.env. */
+  env: Record<string, string | undefined>;
+}
+
+/**
+ * Merges base settings with sesshin additions (statusLine injection).
+ * Opt-out: set SESSHIN_DISABLE_STATUSLINE_RELAY=1 in env to skip injection.
+ */
+export function mergeSettings(params: MergeSettingsParams): Record<string, any> {
+  const merged: Record<string, any> = { ...params.base };
+  if (params.env['SESSHIN_DISABLE_STATUSLINE_RELAY'] !== '1') {
+    merged['statusLine'] = { type: 'command', command: params.relayBinPath };
+  }
+  return merged;
+}

--- a/packages/cli/src/statusline-relay/index.ts
+++ b/packages/cli/src/statusline-relay/index.ts
@@ -1,0 +1,35 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import { runRelay, type RelayDeps } from './relay.js';
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+const realSpawn: RelayDeps['spawn'] = (cmd, args, opts) => new Promise((resolve) => {
+  const child = nodeSpawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '', stderr = '';
+  let timedOut = false;
+  const timer = setTimeout(() => { timedOut = true; child.kill('SIGTERM'); }, opts.timeoutMs);
+  child.stdout.on('data', (d) => { stdout += d.toString('utf-8'); });
+  child.stderr.on('data', (d) => { stderr += d.toString('utf-8'); });
+  child.on('close', (code) => { clearTimeout(timer); resolve({ code, stdout, stderr, timedOut }); });
+  child.on('error', () => { clearTimeout(timer); resolve({ code: 1, stdout, stderr, timedOut }); });
+  child.stdin.write(opts.stdin);
+  child.stdin.end();
+});
+
+export async function main(): Promise<number> {
+  const stdin = await readStdin();
+  return runRelay({
+    stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    env: process.env as RelayDeps['env'],
+    fetch: globalThis.fetch,
+    spawn: realSpawn,
+    fastTimeoutMs: 250,
+    wrapTimeoutMs: 1500,
+  });
+}

--- a/packages/cli/src/statusline-relay/index.ts
+++ b/packages/cli/src/statusline-relay/index.ts
@@ -16,6 +16,10 @@ const realSpawn: RelayDeps['spawn'] = (cmd, args, opts) => new Promise((resolve)
   child.stderr.on('data', (d) => { stderr += d.toString('utf-8'); });
   child.on('close', (code) => { clearTimeout(timer); resolve({ code, stdout, stderr, timedOut }); });
   child.on('error', () => { clearTimeout(timer); resolve({ code: 1, stdout, stderr, timedOut }); });
+  // If spawn fails (e.g. ENOENT), the synchronous writes below would otherwise
+  // emit an unhandled 'error' on stdin and crash the process. Swallow it here;
+  // the child.on('error') handler already resolves the promise cleanly.
+  child.stdin.on('error', () => { /* see comment above */ });
   child.stdin.write(opts.stdin);
   child.stdin.end();
 });

--- a/packages/cli/src/statusline-relay/relay.test.ts
+++ b/packages/cli/src/statusline-relay/relay.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { runRelay, type RelayDeps } from './relay.js';
 
 function makeDeps(overrides: Partial<RelayDeps> = {}): RelayDeps {

--- a/packages/cli/src/statusline-relay/relay.test.ts
+++ b/packages/cli/src/statusline-relay/relay.test.ts
@@ -122,4 +122,16 @@ describe('runRelay', () => {
     expect((deps as any)._captured.stderr.join('')).toMatch(/timed out/);
     expect(code).toBe(0);
   });
+
+  it('spawn rejects: falls back to default render, logs to stderr, exits 0', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({ rate_limits: { five_hour: { used_percentage: 12, resets_at: 1 }, seven_day: null } }),
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'broken' },
+      spawn: (() => Promise.reject(new Error('ENOENT: no such file'))) as any,
+    });
+    const code = await runRelay(deps);
+    expect(code).toBe(0);
+    expect((deps as any)._captured.stdout.join('')).toBe('5h: 12% · 7d: -');
+    expect((deps as any)._captured.stderr.join('')).toMatch(/wrapped command failed to start.*ENOENT/);
+  });
 });

--- a/packages/cli/src/statusline-relay/relay.test.ts
+++ b/packages/cli/src/statusline-relay/relay.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runRelay, type RelayDeps } from './relay.js';
+
+function makeDeps(overrides: Partial<RelayDeps> = {}): RelayDeps {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const fetched: any[] = [];
+  return {
+    stdin: '{}',
+    stdout: { write: (s: string) => { stdout.push(s); return true; } },
+    stderr: { write: (s: string) => { stderr.push(s); return true; } },
+    env: { SESSHIN_HUB_URL: 'http://127.0.0.1:9663', SESSHIN_SESSION_ID: 's1' },
+    fetch: async (url: string, init?: any) => {
+      fetched.push({ url, init });
+      return new Response(null, { status: 204 });
+    },
+    spawn: () => { throw new Error('spawn should not be called when SESSHIN_USER_STATUSLINE_CMD is unset'); },
+    fastTimeoutMs: 250,
+    wrapTimeoutMs: 1500,
+    ...overrides,
+    // Re-attach captures so test can assert
+    _captured: { stdout, stderr, fetched },
+  } as any;
+}
+
+describe('runRelay', () => {
+  it('POSTs null windows when rate_limits absent and renders nothing (no wrap)', async () => {
+    const deps = makeDeps({ stdin: '{"model":"claude-opus","other":1}' });
+    const code = await runRelay(deps);
+    expect(code).toBe(0);
+    expect((deps as any)._captured.fetched[0].init.body)
+      .toBe(JSON.stringify({ sessionId: 's1', five_hour: null, seven_day: null }));
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+  });
+
+  it('POSTs both windows when rate_limits present and renders default', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({
+        rate_limits: {
+          five_hour: { used_percentage: 45, resets_at: 100 },
+          seven_day: { used_percentage: 23, resets_at: 200 },
+        },
+      }),
+    });
+    const code = await runRelay(deps);
+    expect(code).toBe(0);
+    const body = JSON.parse((deps as any)._captured.fetched[0].init.body);
+    expect(body.five_hour.used_percentage).toBe(45);
+    expect(body.seven_day.used_percentage).toBe(23);
+    expect((deps as any)._captured.stdout.join('')).toBe('5h: 45% · 7d: 23%');
+  });
+
+  it('renders empty when rate_limits absent and no wrap configured', async () => {
+    const deps = makeDeps({ stdin: '{}' });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+    expect(code).toBe(0);
+  });
+
+  it('partially-present rate_limits POSTs nulls for missing windows', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({ rate_limits: { five_hour: { used_percentage: 1, resets_at: 1 } } }),
+    });
+    await runRelay(deps);
+    const body = JSON.parse((deps as any)._captured.fetched[0].init.body);
+    expect(body.five_hour).toEqual({ used_percentage: 1, resets_at: 1 });
+    expect(body.seven_day).toBeNull();
+  });
+
+  it('malformed stdin JSON: skips POST, runs wrap if configured, exits 0', async () => {
+    const spawnCalls: any[] = [];
+    const deps = makeDeps({
+      stdin: 'not json',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'echo wrapped' },
+      spawn: ((cmd: string, args: string[], opts: any) => {
+        spawnCalls.push({ cmd, args, opts });
+        return Promise.resolve({ code: 0, stdout: 'wrapped', stderr: '' });
+      }) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.fetched).toEqual([]);
+    expect((deps as any)._captured.stdout.join('')).toBe('wrapped');
+    expect(spawnCalls[0].args).toEqual(['-c', 'echo wrapped']);
+    expect(code).toBe(0);
+  });
+
+  it('hub unreachable: POST aborts, wrap still runs, exits 0', async () => {
+    const deps = makeDeps({
+      stdin: '{}',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'cat' },
+      fetch: async () => { throw new Error('connection refused'); },
+      spawn: ((_cmd: string, _args: string[], opts: any) => {
+        return Promise.resolve({ code: 0, stdout: 'ok-' + opts.stdin, stderr: '' });
+      }) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('ok-{}');
+    expect(code).toBe(0);
+  });
+
+  it('wrap command non-zero exit: falls back to default render, logs to stderr', async () => {
+    const deps = makeDeps({
+      stdin: JSON.stringify({ rate_limits: { five_hour: { used_percentage: 10, resets_at: 1 }, seven_day: null } }),
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'broken' },
+      spawn: (() => Promise.resolve({ code: 1, stdout: '', stderr: 'boom' })) as any,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('5h: 10% · 7d: -');
+    expect((deps as any)._captured.stderr.join('')).toMatch(/sesshin-statusline-relay: wrapped command exited 1/);
+    expect(code).toBe(0);
+  });
+
+  it('wrap command times out: kills, falls back to default, exits 0', async () => {
+    const deps = makeDeps({
+      stdin: '{}',
+      env: { SESSHIN_HUB_URL: 'http://x', SESSHIN_SESSION_ID: 's1', SESSHIN_USER_STATUSLINE_CMD: 'sleep 99' },
+      spawn: (() => Promise.resolve({ code: null, stdout: '', stderr: '', timedOut: true })) as any,
+      wrapTimeoutMs: 5,
+    });
+    const code = await runRelay(deps);
+    expect((deps as any)._captured.stdout.join('')).toBe('');
+    expect((deps as any)._captured.stderr.join('')).toMatch(/timed out/);
+    expect(code).toBe(0);
+  });
+});

--- a/packages/cli/src/statusline-relay/relay.ts
+++ b/packages/cli/src/statusline-relay/relay.ts
@@ -6,7 +6,6 @@ export interface RelayDeps {
     SESSHIN_HUB_URL?: string;
     SESSHIN_SESSION_ID?: string;
     SESSHIN_USER_STATUSLINE_CMD?: string;
-    SESSHIN_USER_STATUSLINE_PADDING?: string;
   };
   fetch: typeof globalThis.fetch;
   spawn: (

--- a/packages/cli/src/statusline-relay/relay.ts
+++ b/packages/cli/src/statusline-relay/relay.ts
@@ -54,7 +54,19 @@ export async function runRelay(deps: RelayDeps): Promise<number> {
   // 4. Wrap user's statusline if configured
   const userCmd = deps.env.SESSHIN_USER_STATUSLINE_CMD;
   if (userCmd && userCmd.trim().length > 0) {
-    const r = await deps.spawn('sh', ['-c', userCmd], { stdin: deps.stdin, timeoutMs: deps.wrapTimeoutMs });
+    let r: Awaited<ReturnType<RelayDeps['spawn']>>;
+    try {
+      r = await deps.spawn('sh', ['-c', userCmd], { stdin: deps.stdin, timeoutMs: deps.wrapTimeoutMs });
+    } catch (err) {
+      // Defensive: deps.spawn is contract-bound to resolve (the realSpawn
+      // wrapper in index.ts catches child 'error' events), but a stub or a
+      // future bug could reject. Fall back to the default render rather than
+      // letting the relay process crash and break CC's TUI.
+      const msg = err instanceof Error ? err.message : String(err);
+      deps.stderr.write(`sesshin-statusline-relay: wrapped command failed to start (${msg})\n`);
+      deps.stdout.write(defaultRender(payload));
+      return 0;
+    }
     if (r.timedOut) {
       deps.stderr.write(`sesshin-statusline-relay: wrapped command timed out after ${deps.wrapTimeoutMs}ms\n`);
       deps.stdout.write(defaultRender(payload));

--- a/packages/cli/src/statusline-relay/relay.ts
+++ b/packages/cli/src/statusline-relay/relay.ts
@@ -1,0 +1,90 @@
+export interface RelayDeps {
+  stdin: string;
+  stdout: { write: (s: string) => boolean | void };
+  stderr: { write: (s: string) => boolean | void };
+  env: {
+    SESSHIN_HUB_URL?: string;
+    SESSHIN_SESSION_ID?: string;
+    SESSHIN_USER_STATUSLINE_CMD?: string;
+    SESSHIN_USER_STATUSLINE_PADDING?: string;
+  };
+  fetch: typeof globalThis.fetch;
+  spawn: (
+    cmd: string,
+    args: string[],
+    opts: { stdin: string; timeoutMs: number },
+  ) => Promise<{ code: number | null; stdout: string; stderr: string; timedOut?: boolean }>;
+  fastTimeoutMs: number;
+  wrapTimeoutMs: number;
+}
+
+interface RateLimitWindow { used_percentage: number; resets_at: number; }
+interface RateLimitsPayload { five_hour: RateLimitWindow | null; seven_day: RateLimitWindow | null; }
+
+export async function runRelay(deps: RelayDeps): Promise<number> {
+  // 1. Parse stdin (best-effort)
+  let parsed: any = null;
+  let parseOk = false;
+  try { parsed = JSON.parse(deps.stdin); parseOk = true; } catch { /* keep null */ }
+
+  // 2. Extract rate_limits → payload (or skip POST if parse failed)
+  let payload: RateLimitsPayload | null = null;
+  if (parseOk) {
+    const r = parsed?.rate_limits ?? {};
+    payload = {
+      five_hour: extractWindow(r?.five_hour),
+      seven_day: extractWindow(r?.seven_day),
+    };
+  }
+
+  // 3. Fire-and-forget POST (await, but bounded)
+  if (payload && deps.env.SESSHIN_HUB_URL && deps.env.SESSHIN_SESSION_ID) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), deps.fastTimeoutMs);
+    try {
+      await deps.fetch(`${deps.env.SESSHIN_HUB_URL}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: deps.env.SESSHIN_SESSION_ID, ...payload }),
+        signal: controller.signal,
+      });
+    } catch { /* swallow */ }
+    finally { clearTimeout(timer); }
+  }
+
+  // 4. Wrap user's statusline if configured
+  const userCmd = deps.env.SESSHIN_USER_STATUSLINE_CMD;
+  if (userCmd && userCmd.trim().length > 0) {
+    const r = await deps.spawn('sh', ['-c', userCmd], { stdin: deps.stdin, timeoutMs: deps.wrapTimeoutMs });
+    if (r.timedOut) {
+      deps.stderr.write(`sesshin-statusline-relay: wrapped command timed out after ${deps.wrapTimeoutMs}ms\n`);
+      deps.stdout.write(defaultRender(payload));
+      return 0;
+    }
+    if (r.code !== 0) {
+      deps.stderr.write(`sesshin-statusline-relay: wrapped command exited ${r.code}\n`);
+      deps.stdout.write(defaultRender(payload));
+      return 0;
+    }
+    deps.stdout.write(r.stdout);
+    return 0;
+  }
+
+  // 5. Default render
+  deps.stdout.write(defaultRender(payload));
+  return 0;
+}
+
+function extractWindow(w: any): RateLimitWindow | null {
+  if (!w || typeof w !== 'object') return null;
+  if (typeof w.used_percentage !== 'number' || typeof w.resets_at !== 'number') return null;
+  return { used_percentage: w.used_percentage, resets_at: w.resets_at };
+}
+
+function defaultRender(payload: RateLimitsPayload | null): string {
+  if (!payload) return '';
+  const five = payload.five_hour ? `${Math.round(payload.five_hour.used_percentage)}%` : '-';
+  const seven = payload.seven_day ? `${Math.round(payload.seven_day.used_percentage)}%` : '-';
+  if (five === '-' && seven === '-') return '';
+  return `5h: ${five} · 7d: ${seven}`;
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsup';
 export default defineConfig({
-  entry: ['src/main.ts'],
+  entry: { main: 'src/main.ts', 'statusline-relay': 'src/statusline-relay/index.ts' },
   format: ['esm'], target: 'node22', clean: true, sourcemap: true,
 });

--- a/packages/debug-web/src/components/RateLimitsPill.test.tsx
+++ b/packages/debug-web/src/components/RateLimitsPill.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from 'preact';
+import { RateLimitsPill } from './RateLimitsPill.js';
+import { rateLimitsBySession, applyRateLimits } from '../store.js';
+
+beforeEach(() => {
+  rateLimitsBySession.value = {};
+});
+
+function mount(sessionId: string): HTMLDivElement {
+  const div = document.createElement('div');
+  render(<RateLimitsPill sessionId={sessionId} />, div);
+  return div;
+}
+
+describe('RateLimitsPill', () => {
+  it('does not render when no entry exists for the session', () => {
+    const div = mount('s1');
+    expect(div.firstChild).toBeNull();
+  });
+
+  it('does not render when both windows are null (API-key user)', () => {
+    applyRateLimits('s1', { five_hour: null, seven_day: null, observed_at: Date.now() });
+    const div = mount('s1');
+    expect(div.firstChild).toBeNull();
+  });
+
+  it('renders both windows when fresh', () => {
+    const now = Date.now();
+    applyRateLimits('s1', {
+      five_hour: { used_percentage: 45, resets_at: Math.floor(now / 1000) + 7320 },
+      seven_day: { used_percentage: 23, resets_at: Math.floor(now / 1000) + 86400 },
+      observed_at: now,
+    });
+    const div = mount('s1');
+    expect(div.textContent).toMatch(/5h:\s*45%/);
+    expect(div.textContent).toMatch(/7d:\s*23%/);
+  });
+
+  it('applies amber color when 5h utilization is in [70, 90)', () => {
+    applyRateLimits('s1', {
+      five_hour: { used_percentage: 80, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now(),
+    });
+    const div = mount('s1');
+    const el = div.firstChild as HTMLElement;
+    expect(el.style.color).toBe('rgb(245, 158, 11)');
+  });
+
+  it('applies red color when 5h utilization >= 90', () => {
+    applyRateLimits('s1', {
+      five_hour: { used_percentage: 95, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now(),
+    });
+    const div = mount('s1');
+    expect((div.firstChild as HTMLElement).style.color).toBe('rgb(239, 68, 68)');
+  });
+
+  it('dims when observed_at is older than 10 minutes', () => {
+    applyRateLimits('s1', {
+      five_hour: { used_percentage: 10, resets_at: Math.floor(Date.now() / 1000) + 100 },
+      seven_day: null,
+      observed_at: Date.now() - 11 * 60 * 1000,
+    });
+    const div = mount('s1');
+    expect((div.firstChild as HTMLElement).style.opacity).toBe('0.5');
+  });
+});

--- a/packages/debug-web/src/components/RateLimitsPill.test.tsx
+++ b/packages/debug-web/src/components/RateLimitsPill.test.tsx
@@ -1,15 +1,25 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render } from 'preact';
 import { RateLimitsPill } from './RateLimitsPill.js';
 import { rateLimitsBySession, applyRateLimits } from '../store.js';
+
+const mounted: HTMLDivElement[] = [];
 
 beforeEach(() => {
   rateLimitsBySession.value = {};
 });
 
+afterEach(() => {
+  // Tear down each mount so the component's setInterval cleanup fires;
+  // otherwise timers leak across tests and can produce flake.
+  for (const div of mounted) render(null, div);
+  mounted.length = 0;
+});
+
 function mount(sessionId: string): HTMLDivElement {
   const div = document.createElement('div');
   render(<RateLimitsPill sessionId={sessionId} />, div);
+  mounted.push(div);
   return div;
 }
 

--- a/packages/debug-web/src/components/RateLimitsPill.tsx
+++ b/packages/debug-web/src/components/RateLimitsPill.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'preact/hooks';
+import { rateLimitsBySession } from '../store.js';
+import type { RateLimitsState } from '@sesshin/shared';
+
+const COLOR_DEFAULT = '#eee';
+const COLOR_AMBER   = 'rgb(245, 158, 11)';
+const COLOR_RED     = 'rgb(239, 68, 68)';
+const STALE_MS      = 10 * 60 * 1000;
+
+interface Props { sessionId: string; }
+
+export function RateLimitsPill({ sessionId }: Props) {
+  const [, force] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => force((n) => n + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const state = rateLimitsBySession.value[sessionId];
+  if (!state) return null;
+  if (!state.five_hour && !state.seven_day) return null;
+
+  const now = Date.now();
+  const stale = now - state.observed_at >= STALE_MS;
+  const five  = state.five_hour;
+  const seven = state.seven_day;
+
+  const fivePart  = five  ? `5h: ${Math.round(five.used_percentage)}%`  : '5h: -';
+  const sevenPart = seven ? `7d: ${Math.round(seven.used_percentage)}%` : '7d: -';
+
+  const reset = five ?? seven;
+  const resetMs = reset ? reset.resets_at * 1000 - now : null;
+  const resetPart = resetMs !== null && resetMs > 0 ? ` · in ${formatDuration(resetMs)}` : '';
+
+  const fiveColor = (() => {
+    if (!five) return COLOR_DEFAULT;
+    if (five.used_percentage >= 90) return COLOR_RED;
+    if (five.used_percentage >= 70) return COLOR_AMBER;
+    return COLOR_DEFAULT;
+  })();
+
+  const tooltip = buildTooltip(state, now);
+
+  return (
+    <span
+      title={tooltip}
+      data-testid="rate-limits-pill"
+      style={{
+        fontSize: 12,
+        padding: '2px 6px',
+        borderRadius: 4,
+        background: '#1a1a1a',
+        color: fiveColor,
+        opacity: stale ? 0.5 : 1,
+      }}
+    >
+      {stale && '⏱ '}
+      {fivePart} · {sevenPart}{resetPart}
+    </span>
+  );
+}
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const days  = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const mins  = Math.floor((totalSec % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function buildTooltip(state: RateLimitsState, now: number): string {
+  const lines: string[] = [];
+  if (state.five_hour) {
+    const ms = state.five_hour.resets_at * 1000 - now;
+    const at = new Date(state.five_hour.resets_at * 1000).toLocaleTimeString();
+    lines.push(`5h window: ${state.five_hour.used_percentage.toFixed(1)}% used, resets at ${at} (in ${formatDuration(Math.max(0, ms))})`);
+  }
+  if (state.seven_day) {
+    const ms = state.seven_day.resets_at * 1000 - now;
+    const at = new Date(state.seven_day.resets_at * 1000).toLocaleString();
+    lines.push(`7d window: ${state.seven_day.used_percentage.toFixed(1)}% used, resets ${at} (in ${formatDuration(Math.max(0, ms))})`);
+  }
+  const ageSec = Math.floor((now - state.observed_at) / 1000);
+  lines.push(`last update: ${ageSec}s ago`);
+  return lines.join('\n');
+}

--- a/packages/debug-web/src/components/SessionDetail.tsx
+++ b/packages/debug-web/src/components/SessionDetail.tsx
@@ -9,6 +9,7 @@ import { TextInput } from './TextInput.js';
 import { InteractionPanel } from './InteractionPanel.js';
 import { PauseControls } from './PauseControls.js';
 import { CopyBtn } from './CopyBtn.js';
+import { RateLimitsPill } from './RateLimitsPill.js';
 import { TerminalView } from './TerminalView.js';
 import type { WsClient } from '../ws-client.js';
 
@@ -40,6 +41,7 @@ export function SessionDetail({ ws }: { ws: WsClient }) {
         <h2 style={{ margin: 0 }}>{s.name}</h2>
         <StateBadge state={s.state} />
         <ModeBadge mode={s.substate.permissionMode} />
+        <RateLimitsPill sessionId={s.id} />
       </div>
       <div data-testid="session-id-row"
            style={{ display: 'flex', alignItems: 'center', marginBottom: 4, fontSize: 12, opacity: 0.75 }}>

--- a/packages/debug-web/src/store.test.ts
+++ b/packages/debug-web/src/store.test.ts
@@ -3,7 +3,37 @@ import {
   sessions, upsertSession, removeSession,
   promptRequestsBySession, addPromptRequest,
   summariesBySession, eventsBySession,
+  rateLimitsBySession, applyRateLimits,
 } from './store.js';
+import { handleFrame } from './ws-client.js';
+
+describe('rateLimits slice', () => {
+  beforeEach(() => {
+    rateLimitsBySession.value = {};
+  });
+
+  it('starts with an empty object', () => {
+    expect(Object.keys(rateLimitsBySession.value)).toHaveLength(0);
+  });
+
+  it('applyRateLimits writes per session', () => {
+    applyRateLimits('s1', {
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: null,
+      observed_at: 1,
+    });
+    expect(rateLimitsBySession.value['s1']?.five_hour?.used_percentage).toBe(45);
+  });
+
+  it('dispatches session.rate-limits WS messages', () => {
+    handleFrame({
+      type: 'session.rate-limits',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: { used_percentage: 23, resets_at: 200 }, observed_at: 999 },
+    });
+    expect(rateLimitsBySession.value['s1']?.seven_day?.used_percentage).toBe(23);
+  });
+});
 
 describe('removeSession side-effects', () => {
   beforeEach(() => {

--- a/packages/debug-web/src/store.ts
+++ b/packages/debug-web/src/store.ts
@@ -1,6 +1,6 @@
 // packages/debug-web/src/store.ts
 import { signal, computed } from '@preact/signals';
-import type { SessionInfo, Summary, Event } from '@sesshin/shared';
+import type { SessionInfo, Summary, Event, RateLimitsState } from '@sesshin/shared';
 
 export interface PendingPromptRequest {
   sessionId: string;
@@ -24,6 +24,7 @@ export const selectedSessionId = signal<string | null>(null);
 export const summariesBySession = signal<Record<string, Summary[]>>({});
 export const eventsBySession = signal<Record<string, Event[]>>({});
 export const promptRequestsBySession = signal<Record<string, PendingPromptRequest[]>>({});
+export const rateLimitsBySession = signal<Record<string, RateLimitsState>>({});
 export const connected = signal<boolean>(false);
 export const lastEventId = signal<string | null>(null);
 
@@ -53,6 +54,11 @@ export function removeSession(id: string): void {
   deleteSessionKey(summariesBySession, id);
   deleteSessionKey(eventsBySession, id);
   deleteSessionKey(promptRequestsBySession, id);
+  deleteSessionKey(rateLimitsBySession, id);
+}
+
+export function applyRateLimits(sessionId: string, state: RateLimitsState): void {
+  rateLimitsBySession.value = { ...rateLimitsBySession.value, [sessionId]: state };
 }
 
 export function applyConfigChanged(sessionId: string, config: {

--- a/packages/debug-web/src/ws-client.ts
+++ b/packages/debug-web/src/ws-client.ts
@@ -3,6 +3,7 @@ import {
   addSummary, addEvent, lastEventId,
   addPromptRequest, removePromptRequest,
   applyConfigChanged, applyChildSessionChanged,
+  applyRateLimits,
 } from './store.js';
 import type { Action, PromptResponseAnswer } from '@sesshin/shared';
 
@@ -81,7 +82,7 @@ function handleTerminalFrame(m: any): boolean {
   return false;
 }
 
-function handleFrame(m: any): void {
+export function handleFrame(m: any): void {
   if (handleTerminalFrame(m)) return;
   switch (m.type) {
     case 'server.hello': return;
@@ -112,6 +113,9 @@ function handleFrame(m: any): void {
       }); return;
     case 'session.child-changed':
       applyChildSessionChanged(m.sessionId, m.claudeSessionId);
+      return;
+    case 'session.rate-limits':
+      applyRateLimits(m.sessionId, m.rateLimits);
       return;
   }
 }

--- a/packages/hub/src/registry/session-registry.test.ts
+++ b/packages/hub/src/registry/session-registry.test.ts
@@ -112,6 +112,7 @@ describe('SessionRegistry — publicView surfaces sessionFilePath', () => {
     expect('claudeAllowRules' in view).toBe(false);
     expect('lastHeartbeat' in view).toBe(false);
     expect('fileTailCursor' in view).toBe(false);
+    expect('rateLimits' in view).toBe(false);
     // pin, quietUntil, sessionGateOverride are now surfaced in publicView:
     expect('pin' in view).toBe(true);
     expect('quietUntil' in view).toBe(true);

--- a/packages/hub/src/registry/session-registry.test.ts
+++ b/packages/hub/src/registry/session-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import type { RateLimitsState } from '@sesshin/shared';
 import { SessionRegistry } from './session-registry.js';
 
 function makeReg() { return new SessionRegistry(); }
@@ -295,5 +296,30 @@ describe('resetChildScopedState', () => {
   it('no-op on unknown session', () => {
     const r = new SessionRegistry();
     expect(() => r.resetChildScopedState('unknown')).not.toThrow();
+  });
+});
+
+describe('rateLimits', () => {
+  it('returns null before any setRateLimits call', () => {
+    const reg = new SessionRegistry();
+    reg.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    expect(reg.getRateLimits('s1')).toBeNull();
+  });
+
+  it('round-trips a state via setRateLimits / getRateLimits', () => {
+    const reg = new SessionRegistry();
+    reg.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    const state: RateLimitsState = {
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: null,
+      observed_at: 999,
+    };
+    reg.setRateLimits('s1', state);
+    expect(reg.getRateLimits('s1')).toEqual(state);
+  });
+
+  it('setRateLimits on unknown session is a no-op (returns false)', () => {
+    const reg = new SessionRegistry();
+    expect(reg.setRateLimits('missing', { five_hour: null, seven_day: null, observed_at: 1 })).toBe(false);
   });
 });

--- a/packages/hub/src/registry/session-registry.ts
+++ b/packages/hub/src/registry/session-registry.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import type { PermissionMode, SessionInfo, SessionState, Substate } from '@sesshin/shared';
+import type { PermissionMode, RateLimitsState, SessionInfo, SessionState, Substate } from '@sesshin/shared';
 
 export interface RegisterInput {
   id: string;
@@ -40,6 +40,7 @@ export interface SessionRecord extends SessionInfo {
   sessionGateOverride: 'disabled' | 'auto' | 'always' | null;
   pin: string | null;
   quietUntil: number | null;
+  rateLimits: RateLimitsState | null;
 }
 
 export class SessionRegistry extends EventEmitter {
@@ -66,6 +67,7 @@ export class SessionRegistry extends EventEmitter {
       sessionGateOverride: null,
       pin: null,
       quietUntil: null,
+      rateLimits: null,
     };
     this.sessions.set(rec.id, rec);
     this.emit('session-added', this.publicView(rec));
@@ -228,6 +230,17 @@ export class SessionRegistry extends EventEmitter {
 
   getQuietUntil(id: string): number | null {
     return this.sessions.get(id)?.quietUntil ?? null;
+  }
+
+  setRateLimits(id: string, state: RateLimitsState): boolean {
+    const s = this.sessions.get(id);
+    if (!s) return false;
+    s.rateLimits = state;
+    return true;
+  }
+
+  getRateLimits(id: string): RateLimitsState | null {
+    return this.sessions.get(id)?.rateLimits ?? null;
   }
 
   private publicView(s: SessionRecord): SessionInfo {

--- a/packages/hub/src/registry/session-registry.ts
+++ b/packages/hub/src/registry/session-registry.ts
@@ -248,6 +248,11 @@ export class SessionRegistry extends EventEmitter {
       // Stripped fields (private to the hub):
       fileTailCursor: _c, lastHeartbeat: _h,
       claudeAllowRules: _a,
+      // rateLimits is broadcast on its own `session.rate-limits` channel
+      // (and replayed by the WS subscribe handler); keep it out of generic
+      // session events to avoid duplicating it through every state-changed
+      // / config-changed / session.list broadcast.
+      rateLimits: _rl,
       // Surfaced fields stay in `pub`:
       sessionFilePath,
       ...pub

--- a/packages/hub/src/rest/server.test.ts
+++ b/packages/hub/src/rest/server.test.ts
@@ -105,6 +105,78 @@ describe('/api/sessions/:id/paused-state', () => {
   });
 });
 
+describe('POST /reports/rate-limits', () => {
+  it('returns 404 when sessionId is unknown', async () => {
+    const reports: any[] = [];
+    const server = createRestServer({
+      registry: new SessionRegistry(),
+      onRateLimitReport: (env) => { reports.push(env); },
+    });
+    await server.listen(0, '127.0.0.1');
+    const localPort = server.address().port;
+    try {
+      const r = await fetch(`http://127.0.0.1:${localPort}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'missing', five_hour: null, seven_day: null }),
+      });
+      expect(r.status).toBe(404);
+      expect(reports).toEqual([]);
+    } finally { await server.close(); }
+  });
+
+  it('returns 400 on a malformed body', async () => {
+    const reports: any[] = [];
+    const registry = new SessionRegistry();
+    registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    const server = createRestServer({
+      registry,
+      onRateLimitReport: (env) => { reports.push(env); },
+    });
+    await server.listen(0, '127.0.0.1');
+    const localPort = server.address().port;
+    try {
+      const r = await fetch(`http://127.0.0.1:${localPort}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 's1', five_hour: 'not-an-object', seven_day: null }),
+      });
+      expect(r.status).toBe(400);
+      expect(reports).toEqual([]);
+    } finally { await server.close(); }
+  });
+
+  it('returns 204 + invokes onRateLimitReport on a valid body', async () => {
+    const reports: any[] = [];
+    const registry = new SessionRegistry();
+    registry.register({ id: 's1', name: 'a', agent: 'claude-code', cwd: '/', pid: 1, sessionFilePath: '/x' });
+    const server = createRestServer({
+      registry,
+      onRateLimitReport: (env) => { reports.push(env); },
+    });
+    await server.listen(0, '127.0.0.1');
+    const localPort = server.address().port;
+    try {
+      const body = {
+        sessionId: 's1',
+        five_hour: { used_percentage: 45, resets_at: 100 },
+        seven_day: null,
+      };
+      const r = await fetch(`http://127.0.0.1:${localPort}/reports/rate-limits`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      expect(r.status).toBe(204);
+      expect(reports).toHaveLength(1);
+      expect(reports[0].sessionId).toBe('s1');
+      expect(reports[0].state.five_hour).toEqual({ used_percentage: 45, resets_at: 100 });
+      expect(reports[0].state.seven_day).toBeNull();
+      expect(typeof reports[0].state.observed_at).toBe('number');
+    } finally { await server.close(); }
+  });
+});
+
 describe('shutdown', () => {
   it('close() resolves promptly even with active long-poll connections', async () => {
     // Regression: graceful shutdown previously hung forever when long-lived

--- a/packages/hub/src/rest/server.ts
+++ b/packages/hub/src/rest/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { z } from 'zod';
-import { PermissionModeEnum, fingerprintToolInput, type PermissionRequestDecision } from '@sesshin/shared';
+import { PermissionModeEnum, fingerprintToolInput, type PermissionRequestDecision, RateLimitsStateSchema, type RateLimitsState } from '@sesshin/shared';
 import type { SessionRegistry } from '../registry/session-registry.js';
 import type { PtyTap } from '../observers/pty-tap.js';
 import type { ApprovalManager } from '../approval-manager.js';
@@ -50,6 +50,8 @@ export interface RestServerDeps {
    * paused=false means a job (claude) holds foreground.
    */
   onPausedReport?: (sessionId: string, paused: boolean) => void;
+  /** Fired when a rate-limit report arrives via POST /reports/rate-limits. */
+  onRateLimitReport?: (env: { sessionId: string; state: RateLimitsState }) => void;
   /**
    * Called from the stale-cleanup path when a tool-completion event
    * (PostToolUse / PostToolUseFailure / Stop) successfully resolves one or
@@ -83,6 +85,12 @@ const WinsizeBody = z.object({ cols: z.number().int().positive(), rows: z.number
 const PausedReportBody = z.object({ paused: z.boolean() });
 
 const InjectBody = z.object({ data: z.string(), source: z.string() });
+
+const RateLimitReportBody = z.object({
+  sessionId: z.string(),
+  five_hour: RateLimitsStateSchema.shape.five_hour,
+  seven_day: RateLimitsStateSchema.shape.seven_day,
+});
 
 const HookBody = z.object({
   agent:     z.enum(['claude-code','codex','gemini','other']),
@@ -223,6 +231,25 @@ async function route(req: IncomingMessage, res: ServerResponse, deps: RestServer
     }
     if (method === 'DELETE') return unregisterSession(id, res, deps);
     return void res.writeHead(405).end();
+  }
+
+  if (url.pathname === '/reports/rate-limits') {
+    if (method !== 'POST') return void res.writeHead(405).end();
+    let body: unknown;
+    try { body = await readJson(req); } catch { return void res.writeHead(400).end('bad json'); }
+    const parsed = RateLimitReportBody.safeParse(body);
+    if (!parsed.success) {
+      return void res.writeHead(400, { 'content-type': 'application/json' })
+        .end(JSON.stringify({ error: 'invalid body', issues: parsed.error.issues }));
+    }
+    if (!deps.registry.get(parsed.data.sessionId)) return void res.writeHead(404).end();
+    const state: RateLimitsState = {
+      five_hour:   parsed.data.five_hour,
+      seven_day:   parsed.data.seven_day,
+      observed_at: Date.now(),
+    };
+    deps.onRateLimitReport?.({ sessionId: parsed.data.sessionId, state });
+    return void res.writeHead(204).end();
   }
 
   if (url.pathname === '/hooks') {

--- a/packages/hub/src/wire.test.ts
+++ b/packages/hub/src/wire.test.ts
@@ -560,3 +560,106 @@ describe('child Claude session boundary (Phase B4)', () => {
     expect(innerCalls.length).toBe(1);
   });
 });
+
+// -----------------------------------------------------------------------------
+// rate-limit report wiring
+//
+// These tests build their own isolated REST + WS pair so they can inject the
+// onRateLimitReport callback that wire.ts's startHub() wires in production.
+// The outer beforeEach's shared servers are not used here.
+// -----------------------------------------------------------------------------
+
+describe('rate-limit report wiring', () => {
+  let rlRegistry: SessionRegistry;
+  let rlWs: WsServerInstance;
+  let rlRest: RestServer;
+  let rlRestPort: number;
+  let rlBroadcasts: object[];
+
+  beforeEach(async () => {
+    rlRegistry = new SessionRegistry();
+    let wsRef: WsServerInstance | undefined;
+
+    rlWs = createWsServer({
+      registry: rlRegistry,
+      bus:       new EventBus(),
+      tap:       new PtyTap({ ringBytes: 1024 }),
+      staticDir: null,
+      approvals: new ApprovalManager({ defaultTimeoutMs: 1000 }),
+      onInput:   async () => ({ ok: true }),
+    });
+
+    rlBroadcasts = [];
+    const realBroadcast = rlWs.broadcast.bind(rlWs);
+    rlWs.broadcast = (msg: object, filter?: (caps: string[]) => boolean): void => {
+      rlBroadcasts.push(msg);
+      realBroadcast(msg, filter);
+    };
+    wsRef = rlWs;
+
+    rlRest = createRestServer({
+      registry: rlRegistry,
+      approvals: new ApprovalManager({ defaultTimeoutMs: 1000 }),
+      onRateLimitReport: ({ sessionId, state }) => {
+        if (!rlRegistry.setRateLimits(sessionId, state)) return;
+        wsRef?.broadcast({
+          type: 'session.rate-limits',
+          sessionId,
+          rateLimits: state,
+        });
+      },
+    });
+
+    await rlRest.listen(0, '127.0.0.1');
+    await rlWs.listen(0, '127.0.0.1');
+    rlRestPort = rlRest.address().port;
+  });
+
+  afterEach(async () => {
+    await rlRest.close();
+    await rlWs.close();
+  });
+
+  it('stores in registry and broadcasts session.rate-limits', async () => {
+    const sid = randomUUID();
+    rlRegistry.register({
+      id: sid, name: 'n', agent: 'claude-code', cwd: '/x', pid: 1,
+      sessionFilePath: '/x/session.jsonl',
+    });
+
+    const r = await fetch(`http://127.0.0.1:${rlRestPort}/reports/rate-limits`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: sid, five_hour: null, seven_day: null }),
+    });
+    expect(r.status).toBe(204);
+
+    // Registry must have stored the rate limits.
+    expect(rlRegistry.getRateLimits(sid)).toMatchObject({ five_hour: null, seven_day: null });
+
+    // Exactly one broadcast with the correct envelope.
+    const rateLimitBroadcasts = rlBroadcasts.filter(
+      (b) => (b as any).type === 'session.rate-limits',
+    );
+    expect(rateLimitBroadcasts).toHaveLength(1);
+    expect(rateLimitBroadcasts[0]).toMatchObject({
+      type: 'session.rate-limits',
+      sessionId: sid,
+      rateLimits: { five_hour: null, seven_day: null },
+    });
+  });
+
+  it('does not broadcast for an unknown sessionId (REST returns 404)', async () => {
+    const before = rlBroadcasts.length;
+    const r = await fetch(`http://127.0.0.1:${rlRestPort}/reports/rate-limits`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 'no-such-session', five_hour: null, seven_day: null }),
+    });
+    // The REST layer returns 404 for unknown session — onRateLimitReport is never called.
+    expect(r.status).toBe(404);
+    expect(
+      rlBroadcasts.slice(before).find((b) => (b as any).type === 'session.rate-limits'),
+    ).toBeUndefined();
+  });
+});

--- a/packages/hub/src/wire.ts
+++ b/packages/hub/src/wire.ts
@@ -605,6 +605,14 @@ export async function startHub(): Promise<HubInstance> {
     onPausedReport: (sessionId, paused) => {
       registry.patchSubstate(sessionId, { paused });
     },
+    onRateLimitReport: ({ sessionId, state }) => {
+      if (!registry.setRateLimits(sessionId, state)) return;
+      wsRef?.broadcast({
+        type: 'session.rate-limits',
+        sessionId,
+        rateLimits: state,
+      });
+    },
     listClients: (sid) => wsRef?.listClients(sid) ?? [],
     ...adapters.restDeps,
   });

--- a/packages/hub/src/ws/connection.test.ts
+++ b/packages/hub/src/ws/connection.test.ts
@@ -424,3 +424,38 @@ describe('session.config-changed runtime broadcast', () => {
     client.close();
   });
 });
+
+describe('subscribe-time replay of rate-limits', () => {
+  it('replay includes session.rate-limits when state exists', async () => {
+    const sid = registerSession();
+    const rlState = { five_hour: null, seven_day: null, observed_at: 1746000000000 };
+    registry.setRateLimits(sid, rlState);
+
+    const client = await connectClient(['state']);
+    const frames = collectFrames(client);
+
+    client.send(JSON.stringify({ type: 'subscribe', sessions: [sid], since: null }));
+    await waitFor(() => frames.some((f) => f.type === 'session.rate-limits'));
+
+    const rl = frames.find((f) => f.type === 'session.rate-limits');
+    expect(rl).toBeDefined();
+    expect(rl.sessionId).toBe(sid);
+    expect(rl.rateLimits).toEqual(rlState);
+    client.close();
+  });
+
+  it('replay omits session.rate-limits when state is null', async () => {
+    const sid = registerSession();
+    // Do NOT call registry.setRateLimits — state remains null.
+
+    const client = await connectClient(['state']);
+    const frames = collectFrames(client);
+
+    client.send(JSON.stringify({ type: 'subscribe', sessions: [sid], since: null }));
+    await waitFor(() => frames.some((f) => f.type === 'session.list'));
+    await delay(100);  // give it time to NOT send anything
+
+    expect(frames.find((f) => f.type === 'session.rate-limits')).toBeUndefined();
+    client.close();
+  });
+});

--- a/packages/hub/src/ws/connection.ts
+++ b/packages/hub/src/ws/connection.ts
@@ -209,6 +209,18 @@ function handleUpstream(
     else                              allSub.detachAllListener();
     if (state.capabilities.has('state')) {
       state.ws.send(JSON.stringify({ type: 'session.list', sessions: deps.registry.list() }));
+      // Replay rate-limits for newly-subscribed sessions so clients that
+      // subscribe after the last relay POST still get the current value.
+      for (const sid of addedForReplay) {
+        const rl = deps.registry.getRateLimits(sid);
+        if (rl) {
+          state.ws.send(JSON.stringify({
+            type: 'session.rate-limits',
+            sessionId: sid,
+            rateLimits: rl,
+          }));
+        }
+      }
     }
     // Replay current pending prompt-requests for newly-added sessions.
     // Only sessions that just appeared in the subscription set (addedForReplay)
@@ -229,16 +241,6 @@ function handleUpstream(
             questions: entry.questions,
           }));
         }
-      }
-    }
-    for (const sid of addedForReplay) {
-      const rl = deps.registry.getRateLimits(sid);
-      if (rl) {
-        state.ws.send(JSON.stringify({
-          type: 'session.rate-limits',
-          sessionId: sid,
-          rateLimits: rl,
-        }));
       }
     }
     if (msg.since && state.capabilities.has('events')) {

--- a/packages/hub/src/ws/connection.ts
+++ b/packages/hub/src/ws/connection.ts
@@ -231,6 +231,16 @@ function handleUpstream(
         }
       }
     }
+    for (const sid of addedForReplay) {
+      const rl = deps.registry.getRateLimits(sid);
+      if (rl) {
+        state.ws.send(JSON.stringify({
+          type: 'session.rate-limits',
+          sessionId: sid,
+          rateLimits: rl,
+        }));
+      }
+    }
     if (msg.since && state.capabilities.has('events')) {
       const sids = state.subscribedTo === 'all' ? deps.registry.list().map((s) => s.id) : Array.from(state.subscribedTo);
       for (const sid of sids) {

--- a/packages/hub/src/ws/server.ts
+++ b/packages/hub/src/ws/server.ts
@@ -89,7 +89,8 @@ function capabilityRequiredFor(msgType: string): string | null {
     case 'session.state':
     case 'session.list':
     case 'session.added':
-    case 'session.removed':              return 'state';
+    case 'session.removed':
+    case 'session.rate-limits':          return 'state';
     default:                             return null;
   }
 }

--- a/packages/shared/src/protocol.test.ts
+++ b/packages/shared/src/protocol.test.ts
@@ -4,7 +4,8 @@ import {
   UpstreamMessageSchema, DownstreamMessageSchema,
   SessionListSchema, ServerErrorSchema, PROTOCOL_VERSION,
   SessionPromptRequestResolvedSchema, SessionConfigChangedSchema,
-  SessionChildChangedSchema,
+  SessionChildChangedSchema, RateLimitWindowSchema, RateLimitsStateSchema,
+  SessionRateLimitsSchema,
 } from './protocol.js';
 
 describe('protocol upstream', () => {
@@ -225,5 +226,51 @@ describe('SessionChildChangedSchema', () => {
       reason: 'startup',
     });
     expect(r.type).toBe('session.child-changed');
+  });
+});
+
+describe('RateLimitWindowSchema', () => {
+  it('parses a well-formed window', () => {
+    const r = RateLimitWindowSchema.parse({ used_percentage: 45.2, resets_at: 1714867200 });
+    expect(r).toEqual({ used_percentage: 45.2, resets_at: 1714867200 });
+  });
+  it('rejects when fields are missing', () => {
+    expect(() => RateLimitWindowSchema.parse({ used_percentage: 1 })).toThrow();
+  });
+});
+
+describe('RateLimitsStateSchema', () => {
+  it('parses null windows (API-key user)', () => {
+    const r = RateLimitsStateSchema.parse({ five_hour: null, seven_day: null, observed_at: 1 });
+    expect(r.five_hour).toBeNull();
+    expect(r.seven_day).toBeNull();
+  });
+  it('parses both windows present', () => {
+    const r = RateLimitsStateSchema.parse({
+      five_hour: { used_percentage: 45, resets_at: 100 },
+      seven_day: { used_percentage: 23, resets_at: 200 },
+      observed_at: 999,
+    });
+    expect(r.five_hour?.used_percentage).toBe(45);
+    expect(r.observed_at).toBe(999);
+  });
+});
+
+describe('SessionRateLimitsSchema', () => {
+  it('parses a valid broadcast envelope', () => {
+    const m = SessionRateLimitsSchema.parse({
+      type: 'session.rate-limits',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: null, observed_at: 1 },
+    });
+    expect(m.type).toBe('session.rate-limits');
+    expect(m.sessionId).toBe('s1');
+  });
+  it('rejects wrong type literal', () => {
+    expect(() => SessionRateLimitsSchema.parse({
+      type: 'session.something-else',
+      sessionId: 's1',
+      rateLimits: { five_hour: null, seven_day: null, observed_at: 1 },
+    })).toThrow();
   });
 });

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -254,13 +254,13 @@ export const SessionChildChangedSchema = z.object({
 
 export const RateLimitWindowSchema = z.object({
   used_percentage: z.number(),
-  resets_at:       z.number(),
+  resets_at:       z.number().int(),  // Unix seconds (matches CC's source)
 });
 
 export const RateLimitsStateSchema = z.object({
   five_hour:    RateLimitWindowSchema.nullable(),
   seven_day:    RateLimitWindowSchema.nullable(),
-  observed_at:  z.number(),
+  observed_at:  z.number().int(),     // Unix milliseconds (hub-stamped via Date.now())
 });
 
 export const SessionRateLimitsSchema = z.object({

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -276,6 +276,7 @@ export const DownstreamMessageSchema = z.discriminatedUnion('type', [
   TerminalResizeSchema, TerminalEndedSchema, ServerErrorSchema, ServerPingSchema,
   SessionPromptRequestSchema, SessionPromptRequestResolvedSchema,
   SessionConfigChangedSchema, SessionChildChangedSchema,
+  SessionRateLimitsSchema,
 ]);
 export type DownstreamMessage = z.infer<typeof DownstreamMessageSchema>;
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -252,6 +252,23 @@ export const SessionChildChangedSchema = z.object({
   reason:                  z.enum(['startup','clear','resume','session-end','unknown']),
 });
 
+export const RateLimitWindowSchema = z.object({
+  used_percentage: z.number(),
+  resets_at:       z.number(),
+});
+
+export const RateLimitsStateSchema = z.object({
+  five_hour:    RateLimitWindowSchema.nullable(),
+  seven_day:    RateLimitWindowSchema.nullable(),
+  observed_at:  z.number(),
+});
+
+export const SessionRateLimitsSchema = z.object({
+  type:        z.literal('session.rate-limits'),
+  sessionId:   z.string(),
+  rateLimits:  RateLimitsStateSchema,
+});
+
 export const DownstreamMessageSchema = z.discriminatedUnion('type', [
   ServerHelloSchema, SessionListSchema, SessionAddedSchema, SessionRemovedSchema,
   SessionStateMsgSchema, SessionEventMsgSchema, SessionSummaryMsgSchema,
@@ -270,3 +287,6 @@ export type PromptResponse               = z.infer<typeof PromptResponseSchema>;
 export type PromptResponseAnswer         = z.infer<typeof PromptResponseSchema>['answers'][number];
 export type PromptQuestion               = z.infer<typeof PromptQuestionSchema>;
 export type PromptOption                 = z.infer<typeof PromptOptionSchema>;
+export type RateLimitWindow              = z.infer<typeof RateLimitWindowSchema>;
+export type RateLimitsState              = z.infer<typeof RateLimitsStateSchema>;
+export type SessionRateLimits            = z.infer<typeof SessionRateLimitsSchema>;


### PR DESCRIPTION
## Summary

- New `sesshin-statusline-relay` bin (second tsup entry in `@sesshin/cli`, ~3 KB) reads CC's statusline JSON, fire-and-forgets the 5h/7d quota state to the hub via `POST /reports/rate-limits`, then wraps the user's existing statusLine command (resolved once at session-start from the CC settings hierarchy, passed through via env var) so user customizations are preserved.
- Hub stores per-session `RateLimitsState`, broadcasts a new `session.rate-limits` WS message, and includes it in subscribe-replay frames (capability-gated like the rest of session state).
- debug-web's session header now shows a glanceable pill (`5h: 45% · 7d: 23% · in 2h 12m`) with color thresholds at 70/90% on the 5h utilization, multi-line native tooltip, and stale-dimming after 10 min.
- Opt-out via `SESSHIN_DISABLE_STATUSLINE_RELAY=1`. API-key users (no `rate_limits` field) gracefully render nothing.

Spec: `docs/superpowers/specs/2026-05-07-statusline-rate-limits-design.md`
Plan: `docs/superpowers/plans/2026-05-07-statusline-rate-limits.md`

## Test Plan

- [x] All 5 packages green: shared (84), debug-web (41), hook-handler (11), hub (362), cli (92+1 skipped) — **590 total, +46 vs main**
- [x] Smoke: `echo '{"rate_limits":{"five_hour":{"used_percentage":42,"resets_at":1},"seven_day":null}}' | node packages/cli/bin/sesshin-statusline-relay` prints `5h: 42% · 7d: -`
- [ ] Manual: launch `sesshin claude`, run a prompt, confirm the pill shows in debug-web's session header within one statusline tick
- [ ] Manual: with a user-configured statusLine (e.g. `ccusage`), confirm sesshin's wrap forwards its output without dropping it
- [ ] Manual: with `SESSHIN_DISABLE_STATUSLINE_RELAY=1`, confirm no injection happens and CC's normal statusline takes effect
- [ ] Manual: API-key user (no Pro/Max subscription) — pill should not render, no stderr noise

## Deferred to follow-ups

- Account-aggregated readout across concurrent sessions (per-session storage chosen for v1)
- History / trend graph
- Active probe (hub-initiated refresh between CC ticks)
- Enterprise managed-settings statusLine wrap (path resolution is platform-specific; tracked in code comment in `read-claude-settings.ts`)
- `padding` field on user's original statusLine is read but not currently forwarded (env-var plumbing dropped during review; CC TUI uses our default formatting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a statusline rate-limit readout that captures and displays Claude.ai account quota usage with color-coded visual indicators based on utilization levels.
* Added a rate-limits display pill in the debug interface showing per-session usage across time windows with countdown timers until quota resets.
* Optional opt-out support via environment variable for users who prefer to disable the feature.

## Tests
* Added comprehensive test coverage for rate-limit reporting, relay functionality, and UI component rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->